### PR TITLE
Remote querying + refactor state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _plan.md
+_data/
+.duckdb-skills/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This registers the GitHub repo as a marketplace and installs the plugin. Skills 
 ## Skills
 
 ### `attach-db`
-Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a project-local SQL state file (`.duckdb-skills/state.sql`) so all other skills can restore the session automatically.
+Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a SQL state file so all other skills can restore the session automatically. You can choose to store state in the project directory (`.duckdb-skills/state.sql`) or in your home directory (`~/.duckdb-skills/<project>/state.sql`).
 
 ```
 /duckdb-skills:attach-db my_analytics.duckdb

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This registers the GitHub repo as a marketplace and installs the plugin. Skills 
 ## Skills
 
 ### `attach-db`
-Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a SQL state file (`~/.duckdb-skills/state.sql`) so all other skills can restore the session automatically.
+Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a project-local SQL state file (`.duckdb-skills/state.sql`) so all other skills can restore the session automatically.
 
 ```
 /duckdb-skills:attach-db my_analytics.duckdb

--- a/skills/attach-db/SKILL.md
+++ b/skills/attach-db/SKILL.md
@@ -12,13 +12,9 @@ You are helping the user attach a DuckDB database file for interactive querying.
 
 Database path given: `$0`
 
-The session is stored as a project-local SQL file at `.duckdb-skills/state.sql` (relative to the project root). Any skill can use it with:
-
-```bash
-duckdb -init ".duckdb-skills/state.sql" -c "<QUERY>"
-```
-
 Follow these steps in order, stopping and reporting clearly if any step fails.
+
+**State file convention**: see the "Resolve state directory" section below. All skills share a single `state.sql` file per project. Once resolved, any skill can use it with `duckdb -init "$STATE_DIR/state.sql" -c "<QUERY>"`.
 
 ## Step 1 — Resolve the database path
 
@@ -79,24 +75,59 @@ SELECT count() AS row_count FROM <table_name>;
 
 Collect the column definitions and row counts for the summary.
 
-## Step 5 — Append to the state file
+## Step 5 — Resolve the state directory
 
-`state.sql` is a shared, accumulative init file used by all duckdb-skills. It may already contain macros, LOAD statements, secrets, or other ATTACH statements written by other skills. **Never overwrite it** — always check for duplicates and append.
+Check if a state file already exists in either location:
 
 ```bash
-mkdir -p ".duckdb-skills"
+# Option 1: in the project directory
+test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
+
+# Option 2: in the home directory, scoped by project name
+PROJECT_NAME="$(basename "$PWD")"
+test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
 ```
+
+If **neither exists**, ask the user:
+
+> Where would you like to store the DuckDB session state for this project?
+>
+> 1. **In the project directory** (`.duckdb-skills/state.sql`) — colocated with the project, easy to find. You can choose to gitignore it.
+> 2. **In your home directory** (`~/.duckdb-skills/<project>/state.sql`) — keeps the project directory clean.
+
+Based on their choice:
+
+**Option 1:**
+```bash
+STATE_DIR=".duckdb-skills"
+mkdir -p "$STATE_DIR"
+```
+Then ask: *"Would you like to gitignore `.duckdb-skills/`?"* If yes:
+```bash
+echo '.duckdb-skills/' >> .gitignore
+```
+
+**Option 2:**
+```bash
+PROJECT_NAME="$(basename "$PWD")"
+STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+mkdir -p "$STATE_DIR"
+```
+
+## Step 6 — Append to the state file
+
+`state.sql` is a shared, accumulative init file used by all duckdb-skills. It may already contain macros, LOAD statements, secrets, or other ATTACH statements written by other skills. **Never overwrite it** — always check for duplicates and append.
 
 Derive the database alias from the filename without extension (e.g. `my_data.duckdb` → `my_data`). Check if this ATTACH already exists:
 
 ```bash
-grep -q "ATTACH.*RESOLVED_PATH" ".duckdb-skills/state.sql" 2>/dev/null
+grep -q "ATTACH.*RESOLVED_PATH" "$STATE_DIR/state.sql" 2>/dev/null
 ```
 
 If not already present, append:
 
 ```bash
-cat >> ".duckdb-skills/state.sql" <<'STATESQL'
+cat >> "$STATE_DIR/state.sql" <<'STATESQL'
 ATTACH IF NOT EXISTS 'RESOLVED_PATH' AS my_data;
 USE my_data;
 STATESQL
@@ -104,20 +135,21 @@ STATESQL
 
 Replace `RESOLVED_PATH` and `my_data` with the actual values. If the alias would conflict with an existing one in the file, ask the user for a name.
 
-## Step 6 — Verify the state file works
+## Step 7 — Verify the state file works
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -c "SHOW TABLES;"
+duckdb -init "$STATE_DIR/state.sql" -c "SHOW TABLES;"
 ```
 
 If this fails, fix the state file and retry.
 
-## Step 7 — Report
+## Step 8 — Report
 
 Summarize for the user:
 
 - **Database path**: the resolved absolute path
 - **Alias**: the database alias used in the state file
+- **State file**: the resolved `STATE_DIR/state.sql` path
 - **Tables**: name, column count, row count for each table (or note the DB is empty)
 - Confirm the database is now active for `/duckdb-skills:query`
 

--- a/skills/attach-db/SKILL.md
+++ b/skills/attach-db/SKILL.md
@@ -12,10 +12,10 @@ You are helping the user attach a DuckDB database file for interactive querying.
 
 Database path given: `$0`
 
-The session is stored as a plain SQL file at `$HOME/.duckdb-skills/state.sql`. Any skill can use it with:
+The session is stored as a project-local SQL file at `.duckdb-skills/state.sql` (relative to the project root). Any skill can use it with:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -c "<QUERY>"
+duckdb -init ".duckdb-skills/state.sql" -c "<QUERY>"
 ```
 
 Follow these steps in order, stopping and reporting clearly if any step fails.
@@ -79,30 +79,35 @@ SELECT count() AS row_count FROM <table_name>;
 
 Collect the column definitions and row counts for the summary.
 
-## Step 5 — Write the state file
+## Step 5 — Append to the state file
 
-Create a SQL file that restores the session. The file must be idempotent (safe to run multiple times).
+`state.sql` is a shared, accumulative init file used by all duckdb-skills. It may already contain macros, LOAD statements, secrets, or other ATTACH statements written by other skills. **Never overwrite it** — always check for duplicates and append.
 
 ```bash
-mkdir -p "$HOME/.duckdb-skills"
-cat > "$HOME/.duckdb-skills/state.sql" <<'STATESQL'
--- duckdb-skills session state
--- Generated: TIMESTAMP
-ATTACH 'RESOLVED_PATH' AS db;
-USE db;
+mkdir -p ".duckdb-skills"
+```
+
+Derive the database alias from the filename without extension (e.g. `my_data.duckdb` → `my_data`). Check if this ATTACH already exists:
+
+```bash
+grep -q "ATTACH.*RESOLVED_PATH" ".duckdb-skills/state.sql" 2>/dev/null
+```
+
+If not already present, append:
+
+```bash
+cat >> ".duckdb-skills/state.sql" <<'STATESQL'
+ATTACH IF NOT EXISTS 'RESOLVED_PATH' AS my_data;
+USE my_data;
 STATESQL
 ```
 
-Replace `RESOLVED_PATH` with the actual resolved path and `TIMESTAMP` with the current UTC time.
-
-**Important**: If there is an existing `state.sql`, read it first. If it already contains ATTACH statements, **append** the new ATTACH to the file rather than overwriting — the user may want multiple databases attached. Ask the user whether to replace or append if a state file already exists.
-
-The database alias (`AS db`) should be derived from the filename without extension (e.g. `my_data.duckdb` → `AS my_data`). If the alias would conflict with an existing one in the file, ask the user for a name.
+Replace `RESOLVED_PATH` and `my_data` with the actual values. If the alias would conflict with an existing one in the file, ask the user for a name.
 
 ## Step 6 — Verify the state file works
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -c "SHOW TABLES;"
+duckdb -init ".duckdb-skills/state.sql" -c "SHOW TABLES;"
 ```
 
 If this fails, fix the state file and retry.

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -11,28 +11,29 @@ You are helping the user query data using DuckDB.
 
 Input: `$@`
 
-Session state convention: `.duckdb-skills/state.sql` is a project-local SQL file containing ATTACH/USE/LOAD statements, macros, and secrets. All skills restore the session via `duckdb -init ".duckdb-skills/state.sql" -c "..."`.
-
 Follow these steps in order.
 
-## Step 1 — Determine the mode
+## Step 1 — Resolve state and determine the mode
 
-Check for a session state file:
+Look for an existing state file in either location:
 
 ```bash
-cat ".duckdb-skills/state.sql" 2>/dev/null
+STATE_DIR=""
+test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
+PROJECT_NAME="$(basename "$PWD")"
+test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
 ```
 
-If the file exists, verify the databases it references are still accessible by running:
+If found, verify the databases it references are still accessible:
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -c "SHOW DATABASES;"
+duckdb -init "$STATE_DIR/state.sql" -c "SHOW DATABASES;"
 ```
 
 Now determine the mode:
 
-- **Ad-hoc mode** if: the `--file` flag is present, or the SQL references file paths/literals (e.g. `FROM 'data.csv'`), or there is no state file.
-- **Session mode** if: there is a valid state file and the input references table names, is natural language, or is SQL without file references.
+- **Ad-hoc mode** if: the `--file` flag is present, or the SQL references file paths/literals (e.g. `FROM 'data.csv'`), or `STATE_DIR` is empty.
+- **Session mode** if: `STATE_DIR` is set and the input references table names, is natural language, or is SQL without file references.
 
 If no state file exists and no file is referenced, fall back to ad-hoc mode against `:memory:` — the user must reference files directly in their SQL.
 
@@ -53,7 +54,7 @@ If the input is natural language (not valid SQL), generate SQL using the Friendl
 In **session mode**, first retrieve the schema to inform query generation:
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
 SELECT table_name FROM duckdb_tables() ORDER BY table_name;
 "
 ```
@@ -61,7 +62,7 @@ SELECT table_name FROM duckdb_tables() ORDER BY table_name;
 Then for relevant tables:
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "DESCRIBE <table_name>;"
+duckdb -init "$STATE_DIR/state.sql" -csv -c "DESCRIBE <table_name>;"
 ```
 
 Use the schema context and the Friendly SQL reference to generate the most appropriate query.
@@ -74,7 +75,7 @@ consume excessive tokens when returned to this conversation.
 **Session mode** — check row counts for the tables involved:
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
 SELECT table_name, estimated_size, column_count
 FROM duckdb_tables()
 WHERE table_name IN ('<table1>', '<table2>');
@@ -124,13 +125,13 @@ If multiple files are referenced, include all paths in the `allowed_paths` list.
 **Session mode** (user-trusted database):
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "<QUERY>"
+duckdb -init "$STATE_DIR/state.sql" -csv -c "<QUERY>"
 ```
 
 For multi-line queries, use a heredoc with `-init`:
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv <<'SQL'
+duckdb -init "$STATE_DIR/state.sql" -csv <<'SQL'
 <QUERY>;
 SQL
 ```

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -11,7 +11,7 @@ You are helping the user query data using DuckDB.
 
 Input: `$@`
 
-Session state convention: `/duckdb-skills:attach-db` writes `$HOME/.duckdb-skills/state.sql` — a plain SQL file with ATTACH/USE/LOAD statements. Any skill restores the session via `duckdb -init "$HOME/.duckdb-skills/state.sql" -c "..."`.
+Session state convention: `.duckdb-skills/state.sql` is a project-local SQL file containing ATTACH/USE/LOAD statements, macros, and secrets. All skills restore the session via `duckdb -init ".duckdb-skills/state.sql" -c "..."`.
 
 Follow these steps in order.
 
@@ -20,13 +20,13 @@ Follow these steps in order.
 Check for a session state file:
 
 ```bash
-cat "$HOME/.duckdb-skills/state.sql" 2>/dev/null
+cat ".duckdb-skills/state.sql" 2>/dev/null
 ```
 
 If the file exists, verify the databases it references are still accessible by running:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -c "SHOW DATABASES;"
+duckdb -init ".duckdb-skills/state.sql" -c "SHOW DATABASES;"
 ```
 
 Now determine the mode:
@@ -53,7 +53,7 @@ If the input is natural language (not valid SQL), generate SQL using the Friendl
 In **session mode**, first retrieve the schema to inform query generation:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -csv -c "
+duckdb -init ".duckdb-skills/state.sql" -csv -c "
 SELECT table_name FROM duckdb_tables() ORDER BY table_name;
 "
 ```
@@ -61,7 +61,7 @@ SELECT table_name FROM duckdb_tables() ORDER BY table_name;
 Then for relevant tables:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -csv -c "DESCRIBE <table_name>;"
+duckdb -init ".duckdb-skills/state.sql" -csv -c "DESCRIBE <table_name>;"
 ```
 
 Use the schema context and the Friendly SQL reference to generate the most appropriate query.
@@ -74,7 +74,7 @@ consume excessive tokens when returned to this conversation.
 **Session mode** — check row counts for the tables involved:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -csv -c "
+duckdb -init ".duckdb-skills/state.sql" -csv -c "
 SELECT table_name, estimated_size, column_count
 FROM duckdb_tables()
 WHERE table_name IN ('<table1>', '<table2>');
@@ -124,13 +124,13 @@ If multiple files are referenced, include all paths in the `allowed_paths` list.
 **Session mode** (user-trusted database):
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -csv -c "<QUERY>"
+duckdb -init ".duckdb-skills/state.sql" -csv -c "<QUERY>"
 ```
 
 For multi-line queries, use a heredoc with `-init`:
 
 ```bash
-duckdb -init "$HOME/.duckdb-skills/state.sql" -csv <<'SQL'
+duckdb -init ".duckdb-skills/state.sql" -csv <<'SQL'
 <QUERY>;
 SQL
 ```

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -39,19 +39,32 @@ find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null
 
 Use the URI/URL as-is for `RESOLVED_PATH`. Skip the find step.
 
-## Step 2 — Set up remote access (if needed)
+## Step 2 — Resolve the state directory and set up remote access (if needed)
 
-If the file is remote, ensure the required extensions and secrets are configured. Check if `.duckdb-skills/state.sql` already has the needed setup — if so, use it directly with `duckdb -init ".duckdb-skills/state.sql"` and skip to Step 3.
+Look for an existing state file:
 
-Otherwise, set up access and **persist it to state.sql** so subsequent queries don't need to repeat this:
+```bash
+STATE_DIR=""
+test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
+PROJECT_NAME="$(basename "$PWD")"
+test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+```
+
+If the file is **local** and `STATE_DIR` is set, skip to Step 3. If the file is **local** and no state exists, skip to Step 3 (no state needed for local reads).
+
+If the file is **remote**, state is needed for secrets/extensions. If `STATE_DIR` is empty, ask the user where to store state (same options as `/duckdb-skills:attach-db`):
+
+> 1. **In the project directory** (`.duckdb-skills/`) — optionally gitignored
+> 2. **In your home directory** (`~/.duckdb-skills/<project>/`)
+
+Create the chosen directory, then set up access and **persist it to state.sql**:
 
 ### S3
 
 ```bash
 duckdb :memory: -c "INSTALL httpfs;"
-mkdir -p ".duckdb-skills"
 # credential_chain is safe to store — no actual secrets, delegates to local AWS credentials
-cat >> ".duckdb-skills/state.sql" <<'SQL'
+grep -q "credential_chain" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
 LOAD httpfs;
 CREATE SECRET IF NOT EXISTS __default_s3 (TYPE S3, PROVIDER credential_chain);
 SQL
@@ -61,8 +74,7 @@ SQL
 
 ```bash
 duckdb :memory: -c "INSTALL httpfs;"
-mkdir -p ".duckdb-skills"
-cat >> ".duckdb-skills/state.sql" <<'SQL'
+grep -q "__default_gcs" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
 LOAD httpfs;
 CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, PROVIDER credential_chain);
 SQL
@@ -72,8 +84,7 @@ SQL
 
 ```bash
 duckdb :memory: -c "INSTALL httpfs; INSTALL azure;"
-mkdir -p ".duckdb-skills"
-cat >> ".duckdb-skills/state.sql" <<'SQL'
+grep -q "__default_azure" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
 LOAD httpfs;
 LOAD azure;
 CREATE SECRET IF NOT EXISTS __default_azure (TYPE AZURE, PROVIDER credential_chain);
@@ -84,27 +95,25 @@ SQL
 
 ```bash
 duckdb :memory: -c "INSTALL httpfs;"
-mkdir -p ".duckdb-skills"
-cat >> ".duckdb-skills/state.sql" <<'SQL'
-LOAD httpfs;
-SQL
+grep -q "LOAD httpfs;" "$STATE_DIR/state.sql" 2>/dev/null || echo "LOAD httpfs;" >> "$STATE_DIR/state.sql"
 ```
-
-**Important**: Before appending, check if `state.sql` already contains the relevant LOAD/CREATE SECRET lines to avoid duplicates.
 
 ## Step 3 — Ensure the `read_any` macro is in state.sql
 
-The `read_any` macro dispatches to the right reader based on file extension, using only core DuckDB functions. Check if `state.sql` already defines it:
+The `read_any` macro dispatches to the right reader based on file extension, using only core DuckDB functions.
+
+If `STATE_DIR` is empty (local file, no state created yet), create one now. Ask the user the same location question as above.
+
+Check if `state.sql` already defines the macro:
 
 ```bash
-grep -q "read_any" ".duckdb-skills/state.sql" 2>/dev/null
+grep -q "read_any" "$STATE_DIR/state.sql" 2>/dev/null
 ```
 
 If not, append it:
 
 ```bash
-mkdir -p ".duckdb-skills"
-cat >> ".duckdb-skills/state.sql" <<'SQL'
+cat >> "$STATE_DIR/state.sql" <<'SQL'
 -- read_any: auto-detect file format by extension and dispatch to the right reader
 CREATE OR REPLACE MACRO read_any(file_name) AS TABLE
   WITH json_case AS (FROM read_json_auto(file_name))
@@ -151,9 +160,9 @@ Some readers require core extensions that may not be loaded yet. If the read fai
 ```bash
 duckdb :memory: -c "INSTALL <extension>;"
 # Prepend the LOAD to state.sql so it's available before the macro runs
-grep -q "LOAD <extension>;" ".duckdb-skills/state.sql" 2>/dev/null || sed -i '' '1i\
+grep -q "LOAD <extension>;" "$STATE_DIR/state.sql" 2>/dev/null || sed -i '' '1i\
 LOAD <extension>;
-' ".duckdb-skills/state.sql"
+' "$STATE_DIR/state.sql"
 ```
 
 ## Step 4 — Read the file
@@ -161,7 +170,7 @@ LOAD <extension>;
 **Remote files** (use state.sql for secrets/extensions + macro):
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
 SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH'));
 SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
 FROM read_any('RESOLVED_PATH') LIMIT 10;
@@ -171,7 +180,7 @@ FROM read_any('RESOLVED_PATH') LIMIT 10;
 **Local files** (sandboxed — load state.sql first for the macro, then lock down):
 
 ```bash
-duckdb -init ".duckdb-skills/state.sql" -csv -c "
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
 SET allowed_paths=['RESOLVED_PATH'];
 SET enable_external_access=false;
 SET allow_persistent_secrets=false;
@@ -216,5 +225,5 @@ Keep these suggestions brief and only show them once — don't repeat on follow-
 
 ## Cross-skill integration
 
-- **Session state**: If `.duckdb-skills/state.sql` exists, the user has an active database session (set up via `/duckdb-skills:attach-db`). If the user asks follow-up queries about a file you just read, suggest using `/duckdb-skills:query` which will pick up any attached databases automatically.
+- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project>/`), the user has an active database session. If the user asks follow-up queries about a file you just read, suggest using `/duckdb-skills:query` which will pick up any attached databases automatically.
 - **Error troubleshooting**: If DuckDB returns a persistent or unclear error (e.g. unsupported format, extension issues), use `/duckdb-skills:duckdb-docs <error keywords>` to search the documentation for guidance.

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -82,14 +82,18 @@ SQL
 
 ### Azure
 
+Azure `credential_chain` requires `ACCOUNT_NAME` unless the URI is fully qualified (e.g. `abfss://container@account.dfs.core.windows.net/path`). For short-form URIs (`az://container/path`), ask the user for their storage account name.
+
 ```bash
 duckdb :memory: -c "INSTALL httpfs; INSTALL azure;"
-grep -q "__default_azure" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
+grep -q "__default_azure" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<SQL
 LOAD httpfs;
 LOAD azure;
-CREATE SECRET IF NOT EXISTS __default_azure (TYPE AZURE, PROVIDER credential_chain);
+CREATE SECRET IF NOT EXISTS __default_azure (TYPE AZURE, PROVIDER credential_chain, ACCOUNT_NAME '${ACCOUNT_NAME}');
 SQL
 ```
+
+Replace `${ACCOUNT_NAME}` with the user's storage account name. If the URI is fully qualified, `ACCOUNT_NAME` can be omitted.
 
 ### HTTPS
 

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -2,9 +2,9 @@
 name: read-file
 description: >
   Read and explore any data file (CSV, JSON, Parquet, Avro, Excel, spatial, …)
-  by filename only — resolves the path automatically. Uses DuckDB + the magic
-  extension for format auto-detection. Installs magic if needed.
-argument-hint: <filename> [question about the data]
+  locally or remotely (S3, HTTPS). Resolves the path automatically. Uses DuckDB
+  with extension-based format detection — no magic extension needed.
+argument-hint: <filename or URL> [question about the data]
 allowed-tools: Bash
 ---
 
@@ -15,7 +15,17 @@ Question: `${1:-describe the data}`
 
 Follow these steps in order, stopping and reporting clearly if any step fails.
 
-## Step 1 — Resolve the filename to a full path
+## Step 1 — Classify and resolve the path
+
+Determine whether the input is **local** or **remote**:
+
+- **S3 URI** (`s3://...`, `s3a://...`, `s3n://...`) → remote, needs S3 secret + httpfs
+- **HTTPS/HTTP URL** (`https://...`, `http://...`) → remote, needs httpfs
+- **GCS URI** (`gs://...`, `gcs://...`) → remote, needs GCS secret + httpfs
+- **Azure URI** (`azure://...`, `az://...`, `abfss://...`) → remote, needs Azure secret + httpfs
+- **Otherwise** → local file
+
+### Local files
 
 ```bash
 find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null
@@ -23,54 +33,176 @@ find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null
 
 - **Zero results** → tell the user the file was not found and stop.
 - **More than one result** → list all matches, ask the user to re-run with a fuller path, and stop.
-- **Exactly one result** → use that full path for all subsequent steps (`RESOLVED_PATH`).
+- **Exactly one result** → use that full path (`RESOLVED_PATH`).
 
-## Step 2 — Attempt to read the file (optimistic)
+### Remote files
 
-Try a sandboxed read without loading any extra extensions — this succeeds immediately for
-built-in formats (CSV, plain text):
+Use the URI/URL as-is for `RESOLVED_PATH`. Skip the find step.
+
+## Step 2 — Set up remote access (if needed)
+
+If the file is remote, ensure the required extensions and secrets are configured. Check if `.duckdb-skills/state.sql` already has the needed setup — if so, use it directly with `duckdb -init ".duckdb-skills/state.sql"` and skip to Step 3.
+
+Otherwise, set up access and **persist it to state.sql** so subsequent queries don't need to repeat this:
+
+### S3
 
 ```bash
-duckdb :memory: -csv -c "LOAD magic; SET allowed_paths=['RESOLVED_PATH']; SET enable_external_access=false; SET allow_persistent_secrets=false; SET lock_configuration=true; SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH')); SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH'); FROM read_any('RESOLVED_PATH') LIMIT 10;"
+duckdb :memory: -c "INSTALL httpfs;"
+mkdir -p ".duckdb-skills"
+# credential_chain is safe to store — no actual secrets, delegates to local AWS credentials
+cat >> ".duckdb-skills/state.sql" <<'SQL'
+LOAD httpfs;
+CREATE SECRET IF NOT EXISTS __default_s3 (TYPE S3, PROVIDER credential_chain);
+SQL
 ```
 
-**If this succeeds** → skip to Step 4 (Answer).
+### GCS
+
+```bash
+duckdb :memory: -c "INSTALL httpfs;"
+mkdir -p ".duckdb-skills"
+cat >> ".duckdb-skills/state.sql" <<'SQL'
+LOAD httpfs;
+CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, PROVIDER credential_chain);
+SQL
+```
+
+### Azure
+
+```bash
+duckdb :memory: -c "INSTALL httpfs; INSTALL azure;"
+mkdir -p ".duckdb-skills"
+cat >> ".duckdb-skills/state.sql" <<'SQL'
+LOAD httpfs;
+LOAD azure;
+CREATE SECRET IF NOT EXISTS __default_azure (TYPE AZURE, PROVIDER credential_chain);
+SQL
+```
+
+### HTTPS
+
+```bash
+duckdb :memory: -c "INSTALL httpfs;"
+mkdir -p ".duckdb-skills"
+cat >> ".duckdb-skills/state.sql" <<'SQL'
+LOAD httpfs;
+SQL
+```
+
+**Important**: Before appending, check if `state.sql` already contains the relevant LOAD/CREATE SECRET lines to avoid duplicates.
+
+## Step 3 — Ensure the `read_any` macro is in state.sql
+
+The `read_any` macro dispatches to the right reader based on file extension, using only core DuckDB functions. Check if `state.sql` already defines it:
+
+```bash
+grep -q "read_any" ".duckdb-skills/state.sql" 2>/dev/null
+```
+
+If not, append it:
+
+```bash
+mkdir -p ".duckdb-skills"
+cat >> ".duckdb-skills/state.sql" <<'SQL'
+-- read_any: auto-detect file format by extension and dispatch to the right reader
+CREATE OR REPLACE MACRO read_any(file_name) AS TABLE
+  WITH json_case AS (FROM read_json_auto(file_name))
+     , csv_case AS (FROM read_csv(file_name))
+     , parquet_case AS (FROM read_parquet(file_name))
+     , avro_case AS (FROM read_avro(file_name))
+     , blob_case AS (FROM read_blob(file_name))
+     , spatial_case AS (FROM st_read(file_name))
+     , excel_case AS (FROM read_xlsx(file_name))
+     , sqlite_case AS (FROM sqlite_scan(file_name, (SELECT name FROM sqlite_master(file_name) LIMIT 1)))
+     , ipynb_case AS (
+         WITH nb AS (FROM read_json_auto(file_name))
+         SELECT cell_idx, cell.cell_type,
+                array_to_string(cell.source, '') AS source,
+                cell.execution_count
+         FROM nb, UNNEST(cells) WITH ORDINALITY AS t(cell, cell_idx)
+         ORDER BY cell_idx
+     )
+  FROM query_table(
+    CASE
+      WHEN file_name ILIKE '%.json' OR file_name ILIKE '%.jsonl' OR file_name ILIKE '%.ndjson' OR file_name ILIKE '%.geojson' OR file_name ILIKE '%.geojsonl' OR file_name ILIKE '%.har' THEN 'json_case'
+      WHEN file_name ILIKE '%.csv' OR file_name ILIKE '%.tsv' OR file_name ILIKE '%.tab' OR file_name ILIKE '%.txt' THEN 'csv_case'
+      WHEN file_name ILIKE '%.parquet' OR file_name ILIKE '%.pq' THEN 'parquet_case'
+      WHEN file_name ILIKE '%.avro' THEN 'avro_case'
+      WHEN file_name ILIKE '%.xlsx' OR file_name ILIKE '%.xls' THEN 'excel_case'
+      WHEN file_name ILIKE '%.shp' OR file_name ILIKE '%.gpkg' OR file_name ILIKE '%.fgb' OR file_name ILIKE '%.kml' THEN 'spatial_case'
+      WHEN file_name ILIKE '%.ipynb' THEN 'ipynb_case'
+      WHEN file_name ILIKE '%.db' OR file_name ILIKE '%.sqlite' OR file_name ILIKE '%.sqlite3' THEN 'sqlite_case'
+      ELSE 'blob_case'
+    END
+  );
+SQL
+```
+
+Some readers require core extensions that may not be loaded yet. If the read fails with a missing extension error, install it and add the LOAD to `state.sql` (before the macro definition):
+
+| Reader | Core extension needed |
+|---|---|
+| `st_read`, `read_xlsx` | `spatial` |
+| `sqlite_scan` | `sqlite_scanner` |
+| `read_avro` | built-in (v1.3+) |
+| All others | built-in |
+
+```bash
+duckdb :memory: -c "INSTALL <extension>;"
+# Prepend the LOAD to state.sql so it's available before the macro runs
+grep -q "LOAD <extension>;" ".duckdb-skills/state.sql" 2>/dev/null || sed -i '' '1i\
+LOAD <extension>;
+' ".duckdb-skills/state.sql"
+```
+
+## Step 4 — Read the file
+
+**Remote files** (use state.sql for secrets/extensions + macro):
+
+```bash
+duckdb -init ".duckdb-skills/state.sql" -csv -c "
+SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH'));
+SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
+FROM read_any('RESOLVED_PATH') LIMIT 10;
+"
+```
+
+**Local files** (sandboxed — load state.sql first for the macro, then lock down):
+
+```bash
+duckdb -init ".duckdb-skills/state.sql" -csv -c "
+SET allowed_paths=['RESOLVED_PATH'];
+SET enable_external_access=false;
+SET allow_persistent_secrets=false;
+SET lock_configuration=true;
+SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH'));
+SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
+FROM read_any('RESOLVED_PATH') LIMIT 10;
+"
+```
+
+**If this succeeds** → skip to Step 5 (Answer).
 
 **If this fails** → diagnose the cause:
-- **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb magic@community` to install DuckDB and magic, then retry this step.
-- **Version too old** (e.g. `read_any` or `magic` not recognised) → invoke `/duckdb-skills:install-duckdb --update magic@community` to upgrade, then retry this step.
-- **Missing extension** → continue to Step 3.
+- **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb` and retry.
+- **Access denied / credentials error** (S3, GCS, Azure) → ask the user to verify their credentials are configured locally (e.g. `aws configure`, `gcloud auth`, `az login`). The `credential_chain` provider delegates to the local credential setup.
+- **Missing extension** → install it via `/duckdb-skills:install-duckdb <ext>`, add `LOAD <ext>;` to `state.sql`, and retry.
+- **Wrong reader / parse error** → the macro may have matched the wrong reader. Run the query manually with the correct `read_*` function instead of `read_any`.
+- **Persistent or unclear DuckDB error** → use `/duckdb-skills:duckdb-docs <error keywords>` to search the documentation for guidance.
 
 Notes:
-- All `LOAD` statements must precede `SET enable_external_access=false`.
 - **Spatial files**: `st_read` globs for sidecar files using the filename stem. For spatial
   formats add a stem-wildcard to `allowed_paths`:
   `SET allowed_paths=['RESOLVED_PATH', 'RESOLVED_PATH_WITHOUT_EXTENSION.*']`
 
-## Step 3 — Install required extensions and retry
-
-Detect which extensions are needed, install them, then re-run the read:
-
-```bash
-# 3a — detect required extensions
-duckdb :memory: -csv -c "INSTALL magic FROM community; LOAD magic; SELECT magic_required_extensions('RESOLVED_PATH') AS required_exts;"
-
-# 3b — install all required extensions in one call (skip if list is empty)
-duckdb :memory: -c "INSTALL <ext1>; INSTALL <ext2>;"
-
-# 3c — retry the sandboxed read with all extensions loaded
-duckdb :memory: -csv -c "LOAD magic; LOAD <ext1>; LOAD <ext2>; SET allowed_paths=['RESOLVED_PATH']; SET enable_external_access=false; SET allow_persistent_secrets=false; SET lock_configuration=true; SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH')); SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH'); FROM read_any('RESOLVED_PATH') LIMIT 10;"
-```
-
-The three SELECT statements in 3c produce three result sets printed sequentially in CSV format.
-
-## Step 4 — Answer the question
+## Step 5 — Answer the question
 
 Using the schema, row count, and sample rows gathered above, answer:
 
 `${1:-describe the data: summarize column types, row count, and any notable patterns.}`
 
-## Step 5 — Suggest next steps
+## Step 6 — Suggest next steps
 
 After answering, if the data looks like something the user might want to explore further (multiple columns, non-trivial row count), mention:
 
@@ -84,5 +216,5 @@ Keep these suggestions brief and only show them once — don't repeat on follow-
 
 ## Cross-skill integration
 
-- **Session state**: If `$HOME/.duckdb-skills/state.sql` exists, the user has an active database session (set up via `/duckdb-skills:attach-db`). If the user asks follow-up queries about a file you just read, suggest using `/duckdb-skills:query` which will pick up any attached databases automatically.
+- **Session state**: If `.duckdb-skills/state.sql` exists, the user has an active database session (set up via `/duckdb-skills:attach-db`). If the user asks follow-up queries about a file you just read, suggest using `/duckdb-skills:query` which will pick up any attached databases automatically.
 - **Error troubleshooting**: If DuckDB returns a persistent or unclear error (e.g. unsupported format, extension issues), use `/duckdb-skills:duckdb-docs <error keywords>` to search the documentation for guidance.

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -72,13 +72,35 @@ SQL
 
 ### GCS
 
+DuckDB's built-in GCS support uses the S3 API, which requires [HMAC keys](https://console.cloud.google.com/storage/settings;tab=interoperability) — not native GCP credentials. Explain this to the user and offer two options:
+
+**Option A — HMAC keys** (built-in, no extra extension): The user must have HMAC keys exposed as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables, or provide them directly.
+
 ```bash
 duckdb :memory: -c "INSTALL httpfs;"
-grep -q "__default_gcs" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
+grep -q "__default_gcs" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<SQL
 LOAD httpfs;
-CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, PROVIDER credential_chain);
+CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, KEY_ID '${HMAC_KEY_ID}', SECRET '${HMAC_SECRET}');
 SQL
 ```
+
+Ask the user for their HMAC key ID and secret. If they already have them as env vars, `credential_chain` works:
+
+```sql
+CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, PROVIDER credential_chain);
+```
+
+**Option B — Native GCP credentials** via the [duckdb-gcs](https://github.com/northpolesec/duckdb-gcs) community extension: Uses `gcloud auth application-default login` directly — no HMAC keys needed.
+
+```bash
+duckdb :memory: -c "INSTALL gcs FROM community;"
+grep -q "LOAD gcs;" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
+LOAD gcs;
+CREATE SECRET IF NOT EXISTS __default_gcp (TYPE GCP, PROVIDER credential_chain);
+SQL
+```
+
+Note: this extension uses `gs://` and `gcs://` URLs (same as built-in) but also supports `gcss://` to force its usage over the built-in handler.
 
 ### Azure
 

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -47,9 +47,19 @@ Replace `<SEARCH_PATH>` and `<KEYWORD>` with the resolved values before running.
 
 If Step 2 returns more than 40 rows or the output is very large, offload the results to a temporary DuckDB file so you can query them interactively without flooding the conversation context:
 
+Resolve the state directory first:
+
 ```bash
-mkdir -p ".duckdb-skills"
-duckdb ".duckdb-skills/memories.duckdb" -c "
+STATE_DIR=""
+test -d .duckdb-skills && STATE_DIR=".duckdb-skills"
+PROJECT_NAME="$(basename "$PWD")"
+test -d "$HOME/.duckdb-skills/$PROJECT_NAME" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+# Fall back to project-local if neither exists
+test -z "$STATE_DIR" && STATE_DIR=".duckdb-skills" && mkdir -p "$STATE_DIR"
+```
+
+```bash
+duckdb "$STATE_DIR/memories.duckdb" -c "
 CREATE OR REPLACE TABLE memories AS
 SELECT
   regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
@@ -66,14 +76,14 @@ ORDER BY timestamp;
 Then query the table interactively to drill down:
 
 ```bash
-duckdb ".duckdb-skills/memories.duckdb" -c "SELECT count() FROM memories;"
-duckdb ".duckdb-skills/memories.duckdb" -c "FROM memories WHERE content ILIKE '%<narrower term>%' LIMIT 20;"
+duckdb "$STATE_DIR/memories.duckdb" -c "SELECT count() FROM memories;"
+duckdb "$STATE_DIR/memories.duckdb" -c "FROM memories WHERE content ILIKE '%<narrower term>%' LIMIT 20;"
 ```
 
 Clean up when done:
 
 ```bash
-rm -f ".duckdb-skills/memories.duckdb"
+rm -f "$STATE_DIR/memories.duckdb"
 ```
 
 ## Step 4 — Internalize
@@ -88,5 +98,5 @@ Use this to inform your current response. Do not repeat back the raw logs to the
 
 ## Cross-skill integration
 
-- **Session state**: If `.duckdb-skills/state.sql` exists, you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
+- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
 - **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use `/duckdb-skills:duckdb-docs <error keywords>` to search for guidance.

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -48,8 +48,8 @@ Replace `<SEARCH_PATH>` and `<KEYWORD>` with the resolved values before running.
 If Step 2 returns more than 40 rows or the output is very large, offload the results to a temporary DuckDB file so you can query them interactively without flooding the conversation context:
 
 ```bash
-mkdir -p "$HOME/.duckdb-skills"
-duckdb "$HOME/.duckdb-skills/memories.duckdb" -c "
+mkdir -p ".duckdb-skills"
+duckdb ".duckdb-skills/memories.duckdb" -c "
 CREATE OR REPLACE TABLE memories AS
 SELECT
   regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
@@ -66,14 +66,14 @@ ORDER BY timestamp;
 Then query the table interactively to drill down:
 
 ```bash
-duckdb "$HOME/.duckdb-skills/memories.duckdb" -c "SELECT count() FROM memories;"
-duckdb "$HOME/.duckdb-skills/memories.duckdb" -c "FROM memories WHERE content ILIKE '%<narrower term>%' LIMIT 20;"
+duckdb ".duckdb-skills/memories.duckdb" -c "SELECT count() FROM memories;"
+duckdb ".duckdb-skills/memories.duckdb" -c "FROM memories WHERE content ILIKE '%<narrower term>%' LIMIT 20;"
 ```
 
 Clean up when done:
 
 ```bash
-rm -f "$HOME/.duckdb-skills/memories.duckdb"
+rm -f ".duckdb-skills/memories.duckdb"
 ```
 
 ## Step 4 — Internalize
@@ -88,5 +88,5 @@ Use this to inform your current response. Do not repeat back the raw logs to the
 
 ## Cross-skill integration
 
-- **Session state**: If `$HOME/.duckdb-skills/state.sql` exists, you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
+- **Session state**: If `.duckdb-skills/state.sql` exists, you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
 - **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use `/duckdb-skills:duckdb-docs <error keywords>` to search for guidance.


### PR DESCRIPTION
## Summary

Adds remote file support to `read-file`, replaces the `magic` extension with a native `read_any` table macro, and refactors session state to be project-scoped with user-chosen storage location.

## Changes

### Remote file support (`read-file`)
- Supports S3, GCS, Azure, and HTTPS URLs as input (not just local filenames)
- Sets up `credential_chain` secrets for cloud providers — safe to persist since no actual credentials are stored, just a pointer to the local credential chain (`aws configure`, `gcloud auth`, etc.)
- Persists secrets and LOAD statements to `state.sql` so they're set up once per project

### `read_any` table macro replaces `magic` extension
- Removed dependency on the community `magic` extension
- Added a `read_any(file_name)` DuckDB table macro that dispatches to the right reader based on file extension using CTEs + `query_table()` CASE dispatch (same pattern as the [magic extension source](https://github.com/carlopi/duckdb-magic/blob/main/src/magic_extension.cpp))
- Supports: CSV/TSV/TXT, Parquet, JSON/JSONL/NDJSON/GeoJSON/HAR, Avro, Excel (xlsx), spatial (shp/gpkg/fgb/kml), SQLite, ipynb — all via core extensions only
- Falls back to `read_blob` for unknown formats
- Macro is defined once in `state.sql` and reused by all subsequent reads

### Project-scoped state with user choice
- State is no longer global (`~/.duckdb-skills/state.sql`). Instead, when state is first needed, the user is asked:
  1. **In the project directory** (`.duckdb-skills/state.sql`) — with option to gitignore
  2. **In the home directory** (`~/.duckdb-skills/<project>/state.sql`) — keeps the repo clean
- All skills (`attach-db`, `query`, `read-file`, `read-memories`) use the same resolution logic: check `.duckdb-skills/state.sql` first, then `$HOME/.duckdb-skills/<project>/state.sql`
- `state.sql` is append-only — skills check for duplicates before writing

### Consistency across all skills
- `attach-db`: writes ATTACH/USE to project state, uses `ATTACH IF NOT EXISTS` for idempotency
- `query`: resolves state dir in Step 1, uses `$STATE_DIR/state.sql` for all `-init` calls
- `read-file`: resolves state, sets up remote access + macro, reads via `read_any`
- `read-memories`: resolves state dir for temp `memories.duckdb` offloading

## Test plan

- [x] `read-file` reads a local CSV/JSON/Parquet without magic extension
- [x] `read-file` reads from an S3 URI with credential_chain
- [x] `read-file` reads from an HTTPS URL
- [x] `attach-db` prompts for state location on first use, creates `state.sql`
- [x] `query` picks up state from either location
- [x] `read_any` macro dispatches correctly for each supported format
- [x] State file is append-only — running attach-db twice doesn't duplicate entries
