### PR TITLE
Move to PROJECT_ID, based either on git base folder or current full path

### DIFF
--- a/skills/attach-db/SKILL.md
+++ b/skills/attach-db/SKILL.md
@@ -83,9 +83,10 @@ Check if a state file already exists in either location:
 # Option 1: in the project directory
 test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
 
-# Option 2: in the home directory, scoped by project name
-PROJECT_NAME="$(basename "$PWD")"
-test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+# Option 2: in the home directory, scoped by project root path
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
 ```
 
 If **neither exists**, ask the user:
@@ -93,7 +94,7 @@ If **neither exists**, ask the user:
 > Where would you like to store the DuckDB session state for this project?
 >
 > 1. **In the project directory** (`.duckdb-skills/state.sql`) — colocated with the project, easy to find. You can choose to gitignore it.
-> 2. **In your home directory** (`~/.duckdb-skills/<project>/state.sql`) — keeps the project directory clean.
+> 2. **In your home directory** (`~/.duckdb-skills/<project-id>/state.sql`) — keeps the project directory clean.
 
 Based on their choice:
 
@@ -109,8 +110,9 @@ echo '.duckdb-skills/' >> .gitignore
 
 **Option 2:**
 ```bash
-PROJECT_NAME="$(basename "$PWD")"
-STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
 mkdir -p "$STATE_DIR"
 ```
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -20,8 +20,9 @@ Look for an existing state file in either location:
 ```bash
 STATE_DIR=""
 test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
-PROJECT_NAME="$(basename "$PWD")"
-test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
 ```
 
 If found, verify the databases it references are still accessible:

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -46,8 +46,9 @@ Look for an existing state file:
 ```bash
 STATE_DIR=""
 test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
-PROJECT_NAME="$(basename "$PWD")"
-test -f "$HOME/.duckdb-skills/$PROJECT_NAME/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
 ```
 
 If the file is **local** and `STATE_DIR` is set, skip to Step 3. If the file is **local** and no state exists, skip to Step 3 (no state needed for local reads).
@@ -55,7 +56,7 @@ If the file is **local** and `STATE_DIR` is set, skip to Step 3. If the file is 
 If the file is **remote**, state is needed for secrets/extensions. If `STATE_DIR` is empty, ask the user where to store state (same options as `/duckdb-skills:attach-db`):
 
 > 1. **In the project directory** (`.duckdb-skills/`) — optionally gitignored
-> 2. **In your home directory** (`~/.duckdb-skills/<project>/`)
+> 2. **In your home directory** (`~/.duckdb-skills/<project-id>/`)
 
 Create the chosen directory, then set up access and **persist it to state.sql**:
 

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -52,8 +52,9 @@ Resolve the state directory first:
 ```bash
 STATE_DIR=""
 test -d .duckdb-skills && STATE_DIR=".duckdb-skills"
-PROJECT_NAME="$(basename "$PWD")"
-test -d "$HOME/.duckdb-skills/$PROJECT_NAME" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_NAME"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -d "$HOME/.duckdb-skills/$PROJECT_ID" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
 # Fall back to project-local if neither exists
 test -z "$STATE_DIR" && STATE_DIR=".duckdb-skills" && mkdir -p "$STATE_DIR"
 ```
@@ -98,5 +99,5 @@ Use this to inform your current response. Do not repeat back the raw logs to the
 
 ## Cross-skill integration
 
-- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
+- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
 - **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use `/duckdb-skills:duckdb-docs <error keywords>` to search for guidance.


### PR DESCRIPTION
Minor, would still needed for the docs skill if the other PR doesn't make it in.

I think the idea (discussed with a Claudio) is that using base git folder OR $PWD, and then normalizing that it's how claude tend to do this normalization.

This would avoid two subfolder called `test` to collide.