### PR TITLE
Fix YAML frontmatter parsing error in install-duckdb SKILL.md

### DIFF
--- a/skills/install-duckdb/SKILL.md
+++ b/skills/install-duckdb/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Install or update DuckDB extensions. Each argument is either a plain
   extension name (installs from core) or name@repo (e.g. magic@community).
   Pass --update to update extensions instead of installing.
-argument-hint: [--update] [ext1 ext2@repo ext3 ...]
+argument-hint: "[--update] [ext1 ext2@repo ext3 ...]"
 allowed-tools: Bash
 ---
 


### PR DESCRIPTION
## Summary
- Quote the `argument-hint` value in `skills/install-duckdb/SKILL.md` to fix GitHub's YAML frontmatter parsing error
- Unquoted brackets (`[...]`) were being interpreted as YAML flow sequences, causing: `Error in user YAML: did not find expected key while parsing a block mapping at line 1 column 1`

## Test plan
- [x ] Verify the SKILL.md file renders correctly on GitHub without YAML parsing errors

https://github.com/duckdb/duckdb-skills/blob/main/skills/install-duckdb/SKILL.md
<img width="1018" height="86" alt="image" src="https://github.com/user-attachments/assets/4eaedd34-65df-421d-b53e-def498838475" />
