### PR TITLE
Simplify fast path for read-memories and read-file

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "duckdb-skills",
       "source": "./",
       "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "homepage": "https://duckdb.org",
       "repository": "https://github.com/duckdb/duckdb-skills",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb-skills",
   "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "duckdb",
     "url": "https://github.com/duckdb"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Add the repository as a plugin source and install:
 
 ```
 /plugin marketplace add duckdb/duckdb-skills
+```
+```
 /plugin install duckdb-skills@duckdb-skills
 ```
 

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: read-file
 description: >
-  Read and explore any data file (CSV, JSON, Parquet, Avro, Excel, spatial, …)
-  locally or remotely (S3, HTTPS). Resolves the path automatically. Uses DuckDB
-  with extension-based format detection — no magic extension needed.
+  Read any data file (CSV, JSON, Parquet, Avro, Excel, spatial, SQLite) or remote URL (S3, HTTPS).
+  Use when user references a data file, asks "what's in this file", or wants to preview/profile a dataset.
+  Not for source code.
 argument-hint: <filename or URL> [question about the data]
 allowed-tools: Bash
 ---
@@ -13,135 +13,25 @@ You are helping the user read and analyze a data file using DuckDB.
 Filename given: `$0`
 Question: `${1:-describe the data}`
 
-Follow these steps in order, stopping and reporting clearly if any step fails.
+## Step 1 — Read it
 
-## Step 1 — Classify and resolve the path
+`RESOLVED_PATH` is `$0`. If the user gave a bare filename (no `/`), resolve it to a full path with `find` first.
 
-Determine whether the input is **local** or **remote**:
+Run a single DuckDB command that defines the `read_any` macro inline and reads the file.
 
-- **S3 URI** (`s3://...`, `s3a://...`, `s3n://...`) → remote, needs S3 secret + httpfs
-- **HTTPS/HTTP URL** (`https://...`, `http://...`) → remote, needs httpfs
-- **GCS URI** (`gs://...`, `gcs://...`) → remote, needs GCS secret + httpfs
-- **Azure URI** (`azure://...`, `az://...`, `abfss://...`) → remote, needs Azure secret + httpfs
-- **Otherwise** → local file
+For **remote files**, prepend the necessary LOAD/SECRET before the macro:
 
-### Local files
+| Protocol | Prepend |
+|---|---|
+| `https://` / `http://` | `LOAD httpfs;` |
+| `s3://` | `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| `gs://` / `gcs://` | `LOAD httpfs; CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| `az://` / `azure://` / `abfss://` | `LOAD httpfs; LOAD azure; CREATE SECRET (TYPE AZURE, PROVIDER credential_chain);` |
 
-```bash
-find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null
-```
-
-- **Zero results** → tell the user the file was not found and stop.
-- **More than one result** → list all matches, ask the user to re-run with a fuller path, and stop.
-- **Exactly one result** → use that full path (`RESOLVED_PATH`).
-
-### Remote files
-
-Use the URI/URL as-is for `RESOLVED_PATH`. Skip the find step.
-
-## Step 2 — Resolve the state directory and set up remote access (if needed)
-
-Look for an existing state file:
+For **local files**, no prefix needed.
 
 ```bash
-STATE_DIR=""
-test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
-PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
-test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
-```
-
-If the file is **local** and `STATE_DIR` is set, skip to Step 3. If the file is **local** and no state exists, skip to Step 3 (no state needed for local reads).
-
-If the file is **remote**, state is needed for secrets/extensions. If `STATE_DIR` is empty, ask the user where to store state (same options as `/duckdb-skills:attach-db`):
-
-> 1. **In the project directory** (`.duckdb-skills/`) — optionally gitignored
-> 2. **In your home directory** (`~/.duckdb-skills/<project-id>/`)
-
-Create the chosen directory, then set up access and **persist it to state.sql**:
-
-### S3
-
-```bash
-duckdb :memory: -c "INSTALL httpfs;"
-# credential_chain is safe to store — no actual secrets, delegates to local AWS credentials
-grep -q "credential_chain" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
-LOAD httpfs;
-CREATE SECRET IF NOT EXISTS __default_s3 (TYPE S3, PROVIDER credential_chain);
-SQL
-```
-
-### GCS
-
-DuckDB's built-in GCS support uses the S3 API, which requires [HMAC keys](https://console.cloud.google.com/storage/settings;tab=interoperability) — not native GCP credentials. Explain this to the user and offer two options:
-
-**Option A — HMAC keys** (built-in, no extra extension): The user must have HMAC keys exposed as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables, or provide them directly.
-
-```bash
-duckdb :memory: -c "INSTALL httpfs;"
-grep -q "__default_gcs" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<SQL
-LOAD httpfs;
-CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, KEY_ID '${HMAC_KEY_ID}', SECRET '${HMAC_SECRET}');
-SQL
-```
-
-Ask the user for their HMAC key ID and secret. If they already have them as env vars, `credential_chain` works:
-
-```sql
-CREATE SECRET IF NOT EXISTS __default_gcs (TYPE GCS, PROVIDER credential_chain);
-```
-
-**Option B — Native GCP credentials** via the [duckdb-gcs](https://github.com/northpolesec/duckdb-gcs) community extension: Uses `gcloud auth application-default login` directly — no HMAC keys needed.
-
-```bash
-duckdb :memory: -c "INSTALL gcs FROM community;"
-grep -q "LOAD gcs;" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<'SQL'
-LOAD gcs;
-CREATE SECRET IF NOT EXISTS __default_gcp (TYPE GCP, PROVIDER credential_chain);
-SQL
-```
-
-Note: this extension uses `gs://` and `gcs://` URLs (same as built-in) but also supports `gcss://` to force its usage over the built-in handler.
-
-### Azure
-
-Azure `credential_chain` requires `ACCOUNT_NAME` unless the URI is fully qualified (e.g. `abfss://container@account.dfs.core.windows.net/path`). For short-form URIs (`az://container/path`), ask the user for their storage account name.
-
-```bash
-duckdb :memory: -c "INSTALL httpfs; INSTALL azure;"
-grep -q "__default_azure" "$STATE_DIR/state.sql" 2>/dev/null || cat >> "$STATE_DIR/state.sql" <<SQL
-LOAD httpfs;
-LOAD azure;
-CREATE SECRET IF NOT EXISTS __default_azure (TYPE AZURE, PROVIDER credential_chain, ACCOUNT_NAME '${ACCOUNT_NAME}');
-SQL
-```
-
-Replace `${ACCOUNT_NAME}` with the user's storage account name. If the URI is fully qualified, `ACCOUNT_NAME` can be omitted.
-
-### HTTPS
-
-```bash
-duckdb :memory: -c "INSTALL httpfs;"
-grep -q "LOAD httpfs;" "$STATE_DIR/state.sql" 2>/dev/null || echo "LOAD httpfs;" >> "$STATE_DIR/state.sql"
-```
-
-## Step 3 — Ensure the `read_any` macro is in state.sql
-
-The `read_any` macro dispatches to the right reader based on file extension, using only core DuckDB functions.
-
-If `STATE_DIR` is empty (local file, no state created yet), create one now. Ask the user the same location question as above.
-
-Check if `state.sql` already defines the macro:
-
-```bash
-grep -q "read_any" "$STATE_DIR/state.sql" 2>/dev/null
-```
-
-If not, append it:
-
-```bash
-cat >> "$STATE_DIR/state.sql" <<'SQL'
--- read_any: auto-detect file format by extension and dispatch to the right reader
+duckdb -csv -c "
 CREATE OR REPLACE MACRO read_any(file_name) AS TABLE
   WITH json_case AS (FROM read_json_auto(file_name))
      , csv_case AS (FROM read_csv(file_name))
@@ -172,85 +62,20 @@ CREATE OR REPLACE MACRO read_any(file_name) AS TABLE
       ELSE 'blob_case'
     END
   );
-SQL
-```
 
-Some readers require core extensions that may not be loaded yet. If the read fails with a missing extension error, install it and add the LOAD to `state.sql` (before the macro definition):
-
-| Reader | Core extension needed |
-|---|---|
-| `st_read`, `read_xlsx` | `spatial` |
-| `sqlite_scan` | `sqlite_scanner` |
-| `read_avro` | built-in (v1.3+) |
-| All others | built-in |
-
-```bash
-duckdb :memory: -c "INSTALL <extension>;"
-# Prepend the LOAD to state.sql so it's available before the macro runs
-grep -q "LOAD <extension>;" "$STATE_DIR/state.sql" 2>/dev/null || sed -i '' '1i\
-LOAD <extension>;
-' "$STATE_DIR/state.sql"
-```
-
-## Step 4 — Read the file
-
-**Remote files** (use state.sql for secrets/extensions + macro):
-
-```bash
-duckdb -init "$STATE_DIR/state.sql" -csv -c "
-SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH'));
+DESCRIBE FROM read_any('RESOLVED_PATH');
 SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
-FROM read_any('RESOLVED_PATH') LIMIT 10;
+FROM read_any('RESOLVED_PATH') LIMIT 20;
 "
 ```
 
-**Local files** (sandboxed — load state.sql first for the macro, then lock down):
-
-```bash
-duckdb -init "$STATE_DIR/state.sql" -csv -c "
-SET allowed_paths=['RESOLVED_PATH'];
-SET enable_external_access=false;
-SET allow_persistent_secrets=false;
-SET lock_configuration=true;
-SELECT column_name FROM (DESCRIBE FROM read_any('RESOLVED_PATH'));
-SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
-FROM read_any('RESOLVED_PATH') LIMIT 10;
-"
-```
-
-**If this succeeds** → skip to Step 5 (Answer).
-
-**If this fails** → diagnose the cause:
+**If this fails:**
 - **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb` and retry.
-- **Access denied / credentials error** (S3, GCS, Azure) → ask the user to verify their credentials are configured locally (e.g. `aws configure`, `gcloud auth`, `az login`). The `credential_chain` provider delegates to the local credential setup.
-- **Missing extension** → install it via `/duckdb-skills:install-duckdb <ext>`, add `LOAD <ext>;` to `state.sql`, and retry.
-- **Wrong reader / parse error** → the macro may have matched the wrong reader. Run the query manually with the correct `read_*` function instead of `read_any`.
-- **Persistent or unclear DuckDB error** → use `/duckdb-skills:duckdb-docs <error keywords>` to search the documentation for guidance.
+- **Missing extension** (e.g. spatial files, xlsx, sqlite) → retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
+- **Wrong reader / parse error** → use the correct `read_*` function directly instead of `read_any`.
 
-Notes:
-- **Spatial files**: `st_read` globs for sidecar files using the filename stem. For spatial
-  formats add a stem-wildcard to `allowed_paths`:
-  `SET allowed_paths=['RESOLVED_PATH', 'RESOLVED_PATH_WITHOUT_EXTENSION.*']`
+## Step 2 — Answer
 
-## Step 5 — Answer the question
-
-Using the schema, row count, and sample rows gathered above, answer:
+Using the schema, row count, and sample rows, answer:
 
 `${1:-describe the data: summarize column types, row count, and any notable patterns.}`
-
-## Step 6 — Suggest next steps
-
-After answering, if the data looks like something the user might want to explore further (multiple columns, non-trivial row count), mention:
-
-> *If you want to keep querying this data — filter, aggregate, join with other files — you can use `/duckdb-skills:query`. It supports SQL and natural language questions.*
-
-If the file is large and the user might benefit from persisting it, also suggest:
-
-> *To attach this as a database for repeated queries, run `/duckdb-skills:attach-db <path>`.*
-
-Keep these suggestions brief and only show them once — don't repeat on follow-ups.
-
-## Cross-skill integration
-
-- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project>/`), the user has an active database session. If the user asks follow-up queries about a file you just read, suggest using `/duckdb-skills:query` which will pick up any attached databases automatically.
-- **Error troubleshooting**: If DuckDB returns a persistent or unclear error (e.g. unsupported format, extension issues), use `/duckdb-skills:duckdb-docs <error keywords>` to search the documentation for guidance.

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -1,30 +1,17 @@
 ---
 name: read-memories
 description: >
-  Search past Claude Code session logs to recover your own context.
-  Invoke this proactively when you need to recall past decisions, patterns,
-  or unresolved work — either across all projects or scoped to the current one.
+  Search past Claude Code session logs to recall prior decisions, patterns, or unresolved work.
+  Use when user says "do you remember", "what did we do", references past conversations, or you need context from prior sessions.
 argument-hint: <keyword> [--here]
 allowed-tools: Bash
 ---
 
-Use this to recover your own context from past sessions. Do NOT narrate the
-process to the user — silently run the query, absorb the results, and continue
-with enriched context.
+Search past session logs silently — do NOT narrate the process. Absorb the results and continue with enriched context.
 
-`$0` is the keyword to search for.
-Pass `--here` as a second argument (`$1`) to scope the search to the current project only.
+`$0` is the keyword. Pass `--here` as `$1` to scope to the current project only.
 
-## Step 1 — Set the search path
-
-```bash
-ALL_PROJECTS="$HOME/.claude/projects/*/*.jsonl"
-CURRENT_PROJECT="$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl"
-```
-
-Use `$CURRENT_PROJECT` if `$1` is `--here`, otherwise use `$ALL_PROJECTS`.
-
-## Step 2 — Query
+## Step 1 — Query
 
 ```bash
 duckdb :memory: -c "
@@ -32,7 +19,7 @@ SELECT
   regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
   strftime(timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
   message.role AS role,
-  message.content::VARCHAR AS content
+  left(message.content::VARCHAR, 500) AS content
 FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
 WHERE message::VARCHAR ILIKE '%<KEYWORD>%'
   AND message.role IS NOT NULL
@@ -41,63 +28,12 @@ LIMIT 40;
 "
 ```
 
-Replace `<SEARCH_PATH>` and `<KEYWORD>` with the resolved values before running.
+Search paths:
+- All projects: `$HOME/.claude/projects/*/*.jsonl`
+- Current only (`--here`): `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
 
-## Step 3 — Handle large result sets
+Replace `<SEARCH_PATH>` and `<KEYWORD>` before running.
 
-If Step 2 returns more than 40 rows or the output is very large, offload the results to a temporary DuckDB file so you can query them interactively without flooding the conversation context:
+## Step 2 — Internalize
 
-Resolve the state directory first:
-
-```bash
-STATE_DIR=""
-test -d .duckdb-skills && STATE_DIR=".duckdb-skills"
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
-PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
-test -d "$HOME/.duckdb-skills/$PROJECT_ID" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
-# Fall back to project-local if neither exists
-test -z "$STATE_DIR" && STATE_DIR=".duckdb-skills" && mkdir -p "$STATE_DIR"
-```
-
-```bash
-duckdb "$STATE_DIR/memories.duckdb" -c "
-CREATE OR REPLACE TABLE memories AS
-SELECT
-  regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
-  timestamp::TIMESTAMPTZ AS ts,
-  message.role AS role,
-  message.content::VARCHAR AS content
-FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
-WHERE message::VARCHAR ILIKE '%<KEYWORD>%'
-  AND message.role IS NOT NULL
-ORDER BY timestamp;
-"
-```
-
-Then query the table interactively to drill down:
-
-```bash
-duckdb "$STATE_DIR/memories.duckdb" -c "SELECT count() FROM memories;"
-duckdb "$STATE_DIR/memories.duckdb" -c "FROM memories WHERE content ILIKE '%<narrower term>%' LIMIT 20;"
-```
-
-Clean up when done:
-
-```bash
-rm -f "$STATE_DIR/memories.duckdb"
-```
-
-## Step 4 — Internalize
-
-From the results, extract:
-- Decisions made and their rationale
-- Patterns and conventions established
-- Unresolved items or open TODOs
-- Any corrections the user made to your prior behavior
-
-Use this to inform your current response. Do not repeat back the raw logs to the user.
-
-## Cross-skill integration
-
-- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
-- **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use `/duckdb-skills:duckdb-docs <error keywords>` to search for guidance.
+From the results, extract decisions, patterns, unresolved TODOs, and user corrections. Use this to inform your current response — do not repeat raw logs to the user.


### PR DESCRIPTION
I had a meta chat with `claude`, after noticing the skills were triggered less often.

It seems there are some internal claude metrics that weight against skills that requires multiple user interactions. For this, I moved `read-file` and `read-memories` to take optimistic approach, and only on failure handle missing extensions / credentials / etc.

This should make so that the skills are triggered more often, since now they become better alternative that other options `claude` has, and make them ranked higher.