### PR TITLE
duckdb-docs: stable → lts version filter, bump 0.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "duckdb-skills",
       "source": "./",
       "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "homepage": "https://duckdb.org",
       "repository": "https://github.com/duckdb/duckdb-skills",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb-skills",
   "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "duckdb",
     "url": "https://github.com/duckdb"

--- a/skills/duckdb-docs/SKILL.md
+++ b/skills/duckdb-docs/SKILL.md
@@ -40,7 +40,7 @@ There are two search indexes available:
 
 | Index | Remote URL | Local cache filename | Versions | Use when |
 |-------|-----------|---------------------|----------|----------|
-| **DuckDB docs + blog** | `https://duckdb.org/data/docs-search.duckdb` | `duckdb-docs.duckdb` | `stable`, `current`, `blog` | Default — any DuckDB question |
+| **DuckDB docs + blog** | `https://duckdb.org/data/docs-search.duckdb` | `duckdb-docs.duckdb` | `lts`, `current`, `blog` | Default — any DuckDB question |
 | **DuckLake docs** | `https://ducklake.select/data/docs-search.duckdb` | `ducklake-docs.duckdb` | `stable`, `preview` | Query mentions DuckLake, catalogs, or DuckLake-specific features |
 
 Both indexes share the same schema:
@@ -55,7 +55,7 @@ Both indexes share the same schema:
 | `version` | `VARCHAR` | See table above |
 | `text` | `TEXT` | Full markdown of the chunk |
 
-By default, search **DuckDB docs** and filter to `version = 'stable'`. Use different versions when:
+By default, search **DuckDB docs** and filter to `version = 'lts'`. Use different versions when:
 
 - The user explicitly asks about `current`/nightly features → `version = 'current'`
 - The user asks about a blog post or wants background/motivation → `version = 'blog'`


### PR DESCRIPTION
The DuckDB docs index no longer has a `stable` version — it's now `lts`. Updates the skill and bumps the version.