### PR TITLE
Add Codex support without regressing Claude behavior

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "duckdb-skills",
+  "version": "0.2.1",
+  "description": "DuckDB-powered skills for Codex: read any data file, attach and query DuckDB databases, search DuckDB and DuckLake docs, search past Codex or Claude Code session logs, and install or update DuckDB extensions.",
+  "author": {
+    "name": "duckdb",
+    "url": "https://github.com/duckdb"
+  },
+  "homepage": "https://duckdb.org",
+  "repository": "https://github.com/duckdb/duckdb-skills",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "duckdb",
+    "ducklake",
+    "parquet",
+    "csv",
+    "json",
+    "avro",
+    "excel",
+    "iceberg",
+    "delta",
+    "read-file",
+    "read-memories",
+    "duckdb-docs",
+    "data-exploration",
+    "session-logs",
+    "query",
+    "sql",
+    "attach-db"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "DuckDB Skills",
+    "shortDescription": "DuckDB-powered data exploration skills",
+    "longDescription": "Read local or remote data files, attach and query DuckDB databases, search DuckDB and DuckLake docs, and recover Codex or Claude Code session context with DuckDB-powered skills.",
+    "developerName": "duckdb",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://duckdb.org",
+    "defaultPrompt": [
+      "Use DuckDB Skills to inspect a local Parquet file.",
+      "Use DuckDB Skills to query an attached DuckDB database.",
+      "Use DuckDB Skills to search the DuckDB docs for window functions."
+    ]
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-skills",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "DuckDB-powered skills for Codex: read any data file, attach and query DuckDB databases, search DuckDB and DuckLake docs, search past Codex or Claude Code session logs, and install or update DuckDB extensions.",
   "author": {
     "name": "duckdb",

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ Search DuckDB and DuckLake documentation and blog posts using full-text search a
 
 ### `read-memories`
 Search past Codex or Claude Code session logs to recover context from previous conversations —
-decisions made, patterns established, open TODOs. Returns bounded previews first, then offloads
-full drill-down to a temporary DuckDB file when needed.
+decisions made, patterns established, open TODOs.
 
 ```
 /duckdb-skills:read-memories duckdb --here

--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ To pull the latest version, update the marketplace first and then the plugin:
 
 ## Skills
 
-Examples below use the Claude Code slash-command form. In Codex, invoke the same installed skill
-through the plugin by dropping the leading slash, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file
-variants.parquet what columns does it have?`.
+Examples below use the Claude Code slash-command form. In Codex, invoke the same installed skill through the plugin by dropping the leading slash, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file variants.parquet what columns does it have?`.
 
 ### `attach-db`
 Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a SQL state file so all other skills can restore the session automatically. You can choose to store state in the project directory (`.duckdb-skills/state.sql`) or in your home directory (`~/.duckdb-skills/<project>/state.sql`).

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To pull the latest version, update the marketplace first and then the plugin:
 
 ## Skills
 
-Examples below use the Claude Code slash-command form. In Codex, invoke the same skill names
-through the plugin, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file
+Examples below use the Claude Code slash-command form. In Codex, invoke the same installed skill
+through the plugin by dropping the leading slash, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file
 variants.parquet what columns does it have?`.
 
 ### `attach-db`
@@ -189,16 +189,16 @@ it, following the official
 [Build plugins](https://developers.openai.com/codex/plugins/build) guide. The plugin manifest is
 already included at `.codex-plugin/plugin.json`, and the skills live under `./skills/`.
 
-For a repository-local smoke test of the Codex install path, first install the plugin in Codex and
-then run:
+For a repository-local smoke test of the Codex install path, first install the plugin in Codex,
+point `TARGET_HOME` at that initialized Codex home, and then run:
 
 ```bash
-bash skills/install-duckdb/eval-codex.sh
+TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh
 ```
 
 This exercises `duckdb-skills:install-duckdb` through `codex exec` against the target Codex home.
-If you want isolation, point `TARGET_HOME` at a disposable Codex home where the plugin is already
-installed.
+The eval uses that home for plugin resolution and extension install/update checks, so use a
+disposable Codex home if you want isolation.
 
 ## How the skills work together
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,73 @@
 # duckdb-skills
 
-A [Claude Code](https://claude.ai/code) plugin that adds DuckDB-powered skills for data exploration and session memory.
+A plugin bundle for [Claude Code](https://claude.ai/code) and
+[Codex](https://developers.openai.com/codex/plugins) that adds DuckDB-powered skills for data
+exploration and session memory.
 
 ## Installation
 
-### From the Discover tab (coming soon)
+### Codex (local marketplace install)
+
+This repo includes a Codex plugin manifest at `.codex-plugin/plugin.json`.
+
+Codex supports installing local plugins through the plugin directory and a local marketplace. See
+the official docs for [Plugins](https://developers.openai.com/codex/plugins) and
+[Build plugins](https://developers.openai.com/codex/plugins/build).
+
+One simple setup is a personal marketplace:
+
+```bash
+# 1. Clone the repo where Codex can load local plugins from
+mkdir -p ~/.codex/plugins
+git clone https://github.com/duckdb/duckdb-skills.git ~/.codex/plugins/duckdb-skills
+
+# 2. Create the personal marketplace directory
+mkdir -p ~/.agents/plugins
+```
+
+Then add or update `~/.agents/plugins/marketplace.json` with an entry for the plugin. If you
+already have a personal marketplace file, merge the plugin entry into its `plugins` array instead
+of overwriting the file.
+
+```json
+{
+  "name": "local-plugins",
+  "interface": {
+    "displayName": "Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "duckdb-skills",
+      "source": {
+        "source": "local",
+        "path": "./.codex/plugins/duckdb-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+Then restart Codex, open the plugin directory, and install the plugin:
+
+```text
+codex
+/plugins
+```
+
+After installation, start a new thread and either describe the task directly or type `@` to invoke
+the plugin or one of its bundled skills explicitly.
+
+### Claude Code
+#### From the Discover tab (coming soon)
 
 We are working on submitting this plugin to the official Anthropic marketplace. Once listed, it will appear in the **Discover** tab when you run `/plugin` inside Claude Code.
 
-### From GitHub (available now)
+#### From GitHub (available now)
 
 Add the repository as a plugin source and install:
 
@@ -21,7 +80,7 @@ Add the repository as a plugin source and install:
 
 This registers the GitHub repo as a marketplace and installs the plugin. Skills will be available as `/duckdb-skills:<skill-name>` in all future sessions.
 
-### Updating
+#### Updating
 
 To pull the latest version, update the marketplace first and then the plugin:
 
@@ -31,6 +90,10 @@ To pull the latest version, update the marketplace first and then the plugin:
 ```
 
 ## Skills
+
+Examples below use the Claude Code slash-command form. In Codex, invoke the same skill names
+through the plugin, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file
+variants.parquet what columns does it have?`.
 
 ### `attach-db`
 Attach a DuckDB database file for interactive querying. Explores the schema (tables, columns, row counts) and writes a SQL state file so all other skills can restore the session automatically. You can choose to store state in the project directory (`.duckdb-skills/state.sql`) or in your home directory (`~/.duckdb-skills/<project>/state.sql`).
@@ -68,7 +131,9 @@ Search DuckDB and DuckLake documentation and blog posts using full-text search a
 ```
 
 ### `read-memories`
-Search past Claude Code session logs to recover context from previous conversations — decisions made, patterns established, open TODOs. Offloads large result sets to a temporary DuckDB file for interactive drill-down.
+Search past Codex or Claude Code session logs to recover context from previous conversations —
+decisions made, patterns established, open TODOs. Offloads large result sets to a temporary DuckDB
+file for interactive drill-down.
 
 ```
 /duckdb-skills:read-memories duckdb --here
@@ -116,6 +181,13 @@ You can test individual skills directly:
 ```
 
 **Prerequisites:** DuckDB CLI must be installed. If it isn't, the skills will offer to install it via `/duckdb-skills:install-duckdb`.
+
+### Codex local development
+
+For Codex, clone or copy the plugin into a local plugins directory and point a marketplace entry at
+it, following the official
+[Build plugins](https://developers.openai.com/codex/plugins/build) guide. The plugin manifest is
+already included at `.codex-plugin/plugin.json`, and the skills live under `./skills/`.
 
 ## How the skills work together
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Search DuckDB and DuckLake documentation and blog posts using full-text search a
 
 ### `read-memories`
 Search past Codex or Claude Code session logs to recover context from previous conversations —
-decisions made, patterns established, open TODOs. Offloads large result sets to a temporary DuckDB
-file for interactive drill-down.
+decisions made, patterns established, open TODOs. Returns bounded previews first, then offloads
+full drill-down to a temporary DuckDB file when needed.
 
 ```
 /duckdb-skills:read-memories duckdb --here
@@ -188,6 +188,17 @@ For Codex, clone or copy the plugin into a local plugins directory and point a m
 it, following the official
 [Build plugins](https://developers.openai.com/codex/plugins/build) guide. The plugin manifest is
 already included at `.codex-plugin/plugin.json`, and the skills live under `./skills/`.
+
+For a repository-local smoke test of the Codex install path, first install the plugin in Codex and
+then run:
+
+```bash
+bash skills/install-duckdb/eval-codex.sh
+```
+
+This exercises `duckdb-skills:install-duckdb` through `codex exec` against the target Codex home.
+If you want isolation, point `TARGET_HOME` at a disposable Codex home where the plugin is already
+installed.
 
 ## How the skills work together
 

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -15,8 +15,8 @@ if ! grep -Fq 'Examples below use the Claude Code slash-command form' "$ROOT/REA
     exit 1
 fi
 
-if ! grep -Fq 'Examples below use the Claude Code slash-command form. In Codex, invoke the same installed skill through the plugin by dropping the leading slash, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file variants.parquet what columns does it have?`.' "$ROOT/README.md"; then
-    echo "ERROR: README must keep the Codex inline examples on one line."
+if ! grep -Eq 'Examples below use the Claude Code slash-command form\..*`duckdb-skills:query SELECT 42`.*`duckdb-skills:read-file variants\.parquet what columns does it have\?`' "$ROOT/README.md"; then
+    echo "ERROR: README must keep the Codex invocation contract and inline examples intact."
     exit 1
 fi
 
@@ -25,12 +25,12 @@ if grep -Eq '<(KEYWORD_SQL|CODEX_SCOPE_PREDICATE|CLAUDE_SCOPE_PREDICATE)>' "$ROO
     exit 1
 fi
 
-if ! grep -Fq 'If `HAS_CODEX` is `1`, run Step 2. Otherwise skip directly to Step 3.' "$ROOT/skills/read-memories/SKILL.md"; then
+if ! grep -Eq 'HAS_CODEX.*Step 2.*skip directly to Step 3' "$ROOT/skills/read-memories/SKILL.md"; then
     echo "ERROR: read-memories must explicitly gate the Codex preview query on HAS_CODEX."
     exit 1
 fi
 
-if ! grep -Fq 'If `HAS_CLAUDE` is `1`, run Step 3. Otherwise skip it.' "$ROOT/skills/read-memories/SKILL.md"; then
+if ! grep -Eq 'HAS_CLAUDE.*Step 3.*skip it' "$ROOT/skills/read-memories/SKILL.md"; then
     echo "ERROR: read-memories must explicitly gate the Claude preview query on HAS_CLAUDE."
     exit 1
 fi

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -20,6 +20,11 @@ if ! grep -Fq 'Examples below use the Claude Code slash-command form. In Codex, 
     exit 1
 fi
 
+if grep -Eq '<(KEYWORD_SQL|CODEX_SCOPE_PREDICATE|CLAUDE_SCOPE_PREDICATE)>' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories should interpolate shell variables directly instead of leaving placeholder tokens in the SQL snippets."
+    exit 1
+fi
+
 if ! grep -Fq 'TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
     echo "ERROR: README must require an explicit TARGET_HOME for the Codex eval path."
     exit 1

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -25,6 +25,16 @@ if grep -Eq '<(KEYWORD_SQL|CODEX_SCOPE_PREDICATE|CLAUDE_SCOPE_PREDICATE)>' "$ROO
     exit 1
 fi
 
+if ! grep -Fq 'If `HAS_CODEX` is `1`, run Step 2. Otherwise skip directly to Step 3.' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must explicitly gate the Codex preview query on HAS_CODEX."
+    exit 1
+fi
+
+if ! grep -Fq 'If `HAS_CLAUDE` is `1`, run Step 3. Otherwise skip it.' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must explicitly gate the Claude preview query on HAS_CLAUDE."
+    exit 1
+fi
+
 if ! grep -Fq 'TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
     echo "ERROR: README must require an explicit TARGET_HOME for the Codex eval path."
     exit 1

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-SKILL_REFS="$(rg -n '(/duckdb-skills:|duckdb-skills:)' "$ROOT/skills" --glob 'SKILL.md' || true)"
+SKILL_REFS="$(find "$ROOT/skills" -name 'SKILL.md' -exec grep -nE '(/duckdb-skills:|duckdb-skills:)' {} + 2>/dev/null || true)"
 
 if [ -n "$SKILL_REFS" ]; then
     echo "ERROR: shared SKILL.md files must keep cross-skill references client-neutral."
@@ -10,22 +10,22 @@ if [ -n "$SKILL_REFS" ]; then
     exit 1
 fi
 
-if ! rg -q 'Examples below use the Claude Code slash-command form' "$ROOT/README.md"; then
+if ! grep -Fq 'Examples below use the Claude Code slash-command form' "$ROOT/README.md"; then
     echo "ERROR: README must keep the Claude Code invocation contract explicit."
     exit 1
 fi
 
-if ! rg -q 'duckdb-skills:query SELECT 42' "$ROOT/README.md"; then
-    echo "ERROR: README must document the Codex invocation form."
+if ! grep -Fq 'Examples below use the Claude Code slash-command form. In Codex, invoke the same installed skill through the plugin by dropping the leading slash, for example `duckdb-skills:query SELECT 42` or `duckdb-skills:read-file variants.parquet what columns does it have?`.' "$ROOT/README.md"; then
+    echo "ERROR: README must keep the Codex inline examples on one line."
     exit 1
 fi
 
-if ! rg -q 'TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
+if ! grep -Fq 'TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
     echo "ERROR: README must require an explicit TARGET_HOME for the Codex eval path."
     exit 1
 fi
 
-if rg -q '^bash skills/install-duckdb/eval-codex.sh$' "$ROOT/README.md"; then
+if grep -Fxq 'bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
     echo "ERROR: README must not advertise a standalone eval-codex invocation without TARGET_HOME."
     exit 1
 fi

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SKILL_REFS="$(rg -n '(/duckdb-skills:|duckdb-skills:)' "$ROOT/skills" --glob 'SKILL.md' || true)"
+
+if [ -n "$SKILL_REFS" ]; then
+    echo "ERROR: shared SKILL.md files must keep cross-skill references client-neutral."
+    echo "$SKILL_REFS"
+    exit 1
+fi
+
+if ! rg -q 'Examples below use the Claude Code slash-command form' "$ROOT/README.md"; then
+    echo "ERROR: README must keep the Claude Code invocation contract explicit."
+    exit 1
+fi
+
+if ! rg -q 'duckdb-skills:query SELECT 42' "$ROOT/README.md"; then
+    echo "ERROR: README must document the Codex invocation form."
+    exit 1
+fi
+
+if ! rg -q 'TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh' "$ROOT/README.md"; then
+    echo "ERROR: README must require an explicit TARGET_HOME for the Codex eval path."
+    exit 1
+fi
+
+if rg -q '^bash skills/install-duckdb/eval-codex.sh$' "$ROOT/README.md"; then
+    echo "ERROR: README must not advertise a standalone eval-codex invocation without TARGET_HOME."
+    exit 1
+fi
+
+echo "PASS: doc contracts hold"

--- a/eval-doc-contracts.sh
+++ b/eval-doc-contracts.sh
@@ -20,18 +20,23 @@ if ! grep -Eq 'Examples below use the Claude Code slash-command form\..*`duckdb-
     exit 1
 fi
 
-if grep -Eq '<(KEYWORD_SQL|CODEX_SCOPE_PREDICATE|CLAUDE_SCOPE_PREDICATE)>' "$ROOT/skills/read-memories/SKILL.md"; then
-    echo "ERROR: read-memories should interpolate shell variables directly instead of leaving placeholder tokens in the SQL snippets."
+if ! grep -Fq '$HOME/.claude/projects/*/*.jsonl' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must keep the Claude log path explicit."
     exit 1
 fi
 
-if ! grep -Eq 'HAS_CODEX.*Step 2.*skip directly to Step 3' "$ROOT/skills/read-memories/SKILL.md"; then
-    echo "ERROR: read-memories must explicitly gate the Codex preview query on HAS_CODEX."
+if ! grep -Fq '$HOME/.codex/sessions/*/*/*/*.jsonl' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must keep the Codex log path explicit."
     exit 1
 fi
 
-if ! grep -Eq 'HAS_CLAUDE.*Step 3.*skip it' "$ROOT/skills/read-memories/SKILL.md"; then
-    echo "ERROR: read-memories must explicitly gate the Claude preview query on HAS_CLAUDE."
+if ! grep -Fq 'For Codex `--here`' "$ROOT/skills/read-memories/SKILL.md" || ! grep -Fq '<PROJECT_ROOT>' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must keep the Codex --here guidance explicit."
+    exit 1
+fi
+
+if ! grep -Fq 'Claude Code search paths:' "$ROOT/skills/read-memories/SKILL.md" || ! grep -Fq 'Current only (`--here`):' "$ROOT/skills/read-memories/SKILL.md"; then
+    echo "ERROR: read-memories must keep the Claude --here guidance explicit."
     exit 1
 fi
 

--- a/skills/attach-db/SKILL.md
+++ b/skills/attach-db/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attach-db
 description: >
-  Attach a DuckDB database file for use with /duckdb-skills:query.
+  Attach a DuckDB database file for use with duckdb-skills:query.
   Explores the schema (tables, columns, row counts) and writes a SQL state file
   so subsequent queries can restore this session automatically via duckdb -init.
 argument-hint: <path-to-database.duckdb>
@@ -39,7 +39,7 @@ test -f "$RESOLVED_PATH"
 command -v duckdb
 ```
 
-If not found, delegate to `/duckdb-skills:install-duckdb` and then continue.
+If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
 
 ## Step 3 — Validate the database
 
@@ -153,6 +153,6 @@ Summarize for the user:
 - **Alias**: the database alias used in the state file
 - **State file**: the resolved `STATE_DIR/state.sql` path
 - **Tables**: name, column count, row count for each table (or note the DB is empty)
-- Confirm the database is now active for `/duckdb-skills:query`
+- Confirm the database is now active for `duckdb-skills:query`
 
 If the database is empty, suggest creating tables or importing data.

--- a/skills/attach-db/SKILL.md
+++ b/skills/attach-db/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: attach-db
 description: >
-  Attach a DuckDB database file for use with duckdb-skills:query.
+  Attach a DuckDB database file for use with the `query` skill.
   Explores the schema (tables, columns, row counts) and writes a SQL state file
   so subsequent queries can restore this session automatically via duckdb -init.
 argument-hint: <path-to-database.duckdb>
@@ -39,7 +39,7 @@ test -f "$RESOLVED_PATH"
 command -v duckdb
 ```
 
-If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
+If not found, invoke the `install-duckdb` skill and then continue.
 
 ## Step 3 — Validate the database
 
@@ -153,6 +153,6 @@ Summarize for the user:
 - **Alias**: the database alias used in the state file
 - **State file**: the resolved `STATE_DIR/state.sql` path
 - **Tables**: name, column count, row count for each table (or note the DB is empty)
-- Confirm the database is now active for `duckdb-skills:query`
+- Confirm the database is now active for the `query` skill
 
 If the database is empty, suggest creating tables or importing data.

--- a/skills/duckdb-docs/SKILL.md
+++ b/skills/duckdb-docs/SKILL.md
@@ -20,7 +20,7 @@ Follow these steps in order.
 command -v duckdb
 ```
 
-If not found, delegate to `/duckdb-skills:install-duckdb` and then continue.
+If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
 
 ## Step 2 — Ensure required extensions are installed
 

--- a/skills/duckdb-docs/SKILL.md
+++ b/skills/duckdb-docs/SKILL.md
@@ -20,7 +20,7 @@ Follow these steps in order.
 command -v duckdb
 ```
 
-If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
+If not found, invoke the `install-duckdb` skill and then continue.
 
 ## Step 2 — Ensure required extensions are installed
 

--- a/skills/install-duckdb/SKILL.md
+++ b/skills/install-duckdb/SKILL.md
@@ -27,7 +27,7 @@ If not found, tell the user:
 > - Linux:   `curl -fsSL https://install.duckdb.org | sh`
 > - Windows: `winget install DuckDB.cli`
 >
-> Then re-run `duckdb-skills:install-duckdb`.
+> Then re-run the `install-duckdb` skill.
 
 Stop if DuckDB is not found.
 

--- a/skills/install-duckdb/SKILL.md
+++ b/skills/install-duckdb/SKILL.md
@@ -2,7 +2,7 @@
 name: install-duckdb
 description: >
   Install or update DuckDB extensions. Each argument is either a plain
-  extension name (installs from core) or name@repo (e.g. magic@community).
+  extension name (installs from core) or name@repo (e.g. gcs@community).
   Pass --update to update extensions instead of installing.
 argument-hint: "[--update] [ext1 ext2@repo ext3 ...]"
 allowed-tools: Bash

--- a/skills/install-duckdb/SKILL.md
+++ b/skills/install-duckdb/SKILL.md
@@ -27,7 +27,7 @@ If not found, tell the user:
 > - Linux:   `curl -fsSL https://install.duckdb.org | sh`
 > - Windows: `winget install DuckDB.cli`
 >
-> Then re-run `/duckdb-skills:install-duckdb`.
+> Then re-run `duckdb-skills:install-duckdb`.
 
 Stop if DuckDB is not found.
 

--- a/skills/install-duckdb/eval-codex-guard.sh
+++ b/skills/install-duckdb/eval-codex-guard.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-LOG_FILE="$(mktemp /tmp/duckdb-skills-codex-guard.XXXXXX)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/duckdb-skills-codex-guard.XXXXXX")"
 
 cleanup() {
     rm -f "$LOG_FILE"

--- a/skills/install-duckdb/eval-codex-guard.sh
+++ b/skills/install-duckdb/eval-codex-guard.sh
@@ -16,7 +16,7 @@ if env -u TARGET_HOME bash "$ROOT/skills/install-duckdb/eval-codex.sh" >"$LOG_FI
     exit 1
 fi
 
-if ! rg -q 'TARGET_HOME must point to an initialized Codex home' "$LOG_FILE"; then
+if ! grep -q 'TARGET_HOME must point to an initialized Codex home' "$LOG_FILE"; then
     echo "ERROR: eval-codex.sh did not fail with the expected TARGET_HOME guidance"
     cat "$LOG_FILE"
     exit 1

--- a/skills/install-duckdb/eval-codex-guard.sh
+++ b/skills/install-duckdb/eval-codex-guard.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/duckdb-skills-codex-guard.XXXXXX")"
+TMPDIR_FAIL_LOG="$(mktemp "${TMPDIR:-/tmp}/duckdb-skills-codex-guard.XXXXXX")"
 
 cleanup() {
     rm -f "$LOG_FILE"
+    rm -f "$TMPDIR_FAIL_LOG"
 }
 
 trap cleanup EXIT
@@ -19,6 +21,18 @@ fi
 if ! grep -q 'TARGET_HOME must point to an initialized Codex home' "$LOG_FILE"; then
     echo "ERROR: eval-codex.sh did not fail with the expected TARGET_HOME guidance"
     cat "$LOG_FILE"
+    exit 1
+fi
+
+if env TMPDIR=/dev/null TARGET_HOME=/tmp/unused bash "$ROOT/skills/install-duckdb/eval-codex.sh" >"$TMPDIR_FAIL_LOG" 2>&1; then
+    echo "ERROR: eval-codex.sh succeeded when temp directory creation should fail"
+    cat "$TMPDIR_FAIL_LOG"
+    exit 1
+fi
+
+if ! grep -q 'failed to create temp directory for Codex eval' "$TMPDIR_FAIL_LOG"; then
+    echo "ERROR: eval-codex.sh did not fail with the expected temp directory guidance"
+    cat "$TMPDIR_FAIL_LOG"
     exit 1
 fi
 

--- a/skills/install-duckdb/eval-codex-guard.sh
+++ b/skills/install-duckdb/eval-codex-guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LOG_FILE="$(mktemp /tmp/duckdb-skills-codex-guard.XXXXXX)"
+
+cleanup() {
+    rm -f "$LOG_FILE"
+}
+
+trap cleanup EXIT
+
+if env -u TARGET_HOME bash "$ROOT/skills/install-duckdb/eval-codex.sh" >"$LOG_FILE" 2>&1; then
+    echo "ERROR: eval-codex.sh succeeded without TARGET_HOME"
+    cat "$LOG_FILE"
+    exit 1
+fi
+
+if ! rg -q 'TARGET_HOME must point to an initialized Codex home' "$LOG_FILE"; then
+    echo "ERROR: eval-codex.sh did not fail with the expected TARGET_HOME guidance"
+    cat "$LOG_FILE"
+    exit 1
+fi
+
+echo "PASS: eval-codex.sh requires explicit TARGET_HOME"

--- a/skills/install-duckdb/eval-codex.sh
+++ b/skills/install-duckdb/eval-codex.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# End-to-end evaluations for the install-duckdb skill via Codex.
+# Requires duckdb-skills to already be installed and enabled in the target Codex home.
+#
+# Prerequisites: codex CLI and duckdb must be in PATH. The target Codex home must already have
+# duckdb-skills installed through /plugins and enabled in config.
+#
+# Usage:
+#   bash skills/install-duckdb/eval-codex.sh
+#   TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh
+#   KEEP_TEMP=1 TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh
+
+PLUGIN_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+CODEX_BIN="${CODEX_BIN:-codex}"
+TARGET_HOME="${TARGET_HOME:-$HOME}"
+KEEP_TEMP="${KEEP_TEMP:-0}"
+PASS=0
+FAIL=0
+TIMINGS=()
+TMP_ROOT=$(mktemp -d /tmp/duckdb-skills-codex-eval.XXXXXX)
+
+cleanup() {
+    if [ "$KEEP_TEMP" = "1" ]; then
+        echo "Keeping temp logs: $TMP_ROOT"
+        return
+    fi
+    rm -rf "$TMP_ROOT"
+}
+
+slugify() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-'
+}
+
+run_codex() {
+    local prompt="$1"
+    local mode="$2"
+    local output_file="$3"
+    local log_file="$4"
+
+    if [ "$mode" = "danger" ]; then
+        HOME="$TARGET_HOME" "$CODEX_BIN" exec \
+            --dangerously-bypass-approvals-and-sandbox \
+            --skip-git-repo-check \
+            -C "$PLUGIN_DIR" \
+            -o "$output_file" \
+            "$prompt" >"$log_file" 2>&1
+        return
+    fi
+
+    HOME="$TARGET_HOME" "$CODEX_BIN" exec \
+        --sandbox "$mode" \
+        --skip-git-repo-check \
+        -C "$PLUGIN_DIR" \
+        -o "$output_file" \
+        "$prompt" >"$log_file" 2>&1
+}
+
+require_plugin_smoke() {
+    local output_file="$TMP_ROOT/plugin-smoke.txt"
+    local log_file="$TMP_ROOT/plugin-smoke.log"
+    local prompt="Use duckdb-skills:query SELECT 42. Reply with exactly one line: VALUE=42"
+
+    if ! run_codex "$prompt" "read-only" "$output_file" "$log_file"; then
+        echo "ERROR: Codex smoke test failed before install evals."
+        echo "       Ensure duckdb-skills is already installed in the target Codex home."
+        echo "       Last log lines: $(tail -n 5 "$log_file" 2>/dev/null | tr '\n' ' ')"
+        exit 1
+    fi
+
+    if ! grep -qx 'VALUE=42' "$output_file"; then
+        echo "ERROR: duckdb-skills did not respond to a Codex query smoke test."
+        echo "       Install and enable the plugin in the target Codex home, then retry."
+        echo "       Got: $(head -c 300 "$output_file" 2>/dev/null)"
+        exit 1
+    fi
+}
+
+eval_install_case() {
+    local desc="$1"; shift
+    local args="$1"; shift
+    local exts=("$@")
+    local slug output_file log_file prompt t0 t1 elapsed
+
+    slug=$(slugify "$desc")
+    output_file="$TMP_ROOT/${slug}.txt"
+    log_file="$TMP_ROOT/${slug}.log"
+    prompt="Use duckdb-skills:install-duckdb ${args}. Run the skill now. After it finishes, reply with exactly one line: STATUS=done"
+
+    printf "  %-56s " "$desc"
+    t0=$(date +%s)
+    if ! run_codex "$prompt" "danger" "$output_file" "$log_file"; then
+        t1=$(date +%s)
+        elapsed=$((t1 - t0))
+        TIMINGS+=("$elapsed")
+        echo "FAIL  (${elapsed}s) - codex exec failed"
+        echo "        log: $(tail -n 5 "$log_file" 2>/dev/null | tr '\n' ' ')"
+        ((FAIL++))
+        return
+    fi
+    t1=$(date +%s)
+    elapsed=$((t1 - t0))
+    TIMINGS+=("$elapsed")
+
+    if ! grep -qx 'STATUS=done' "$output_file"; then
+        echo "FAIL  (${elapsed}s) - unexpected skill output"
+        echo "        got: $(head -c 300 "$output_file" 2>/dev/null)"
+        ((FAIL++))
+        return
+    fi
+
+    for ext in "${exts[@]}"; do
+        if ! HOME="$TARGET_HOME" duckdb :memory: -c "LOAD ${ext};" &>/dev/null; then
+            echo "FAIL  (${elapsed}s) - LOAD ${ext} failed after install"
+            echo "        skill output: $(head -c 300 "$output_file" 2>/dev/null)"
+            ((FAIL++))
+            return
+        fi
+    done
+
+    echo "PASS  (${elapsed}s)"
+    ((PASS++))
+}
+
+eval_version_case() {
+    local desc="$1"
+    local slug output_file log_file prompt t0 t1 elapsed
+
+    slug=$(slugify "$desc")
+    output_file="$TMP_ROOT/${slug}.txt"
+    log_file="$TMP_ROOT/${slug}.log"
+    prompt="Use duckdb-skills:install-duckdb --update. Run the skill now. After it finishes, reply with one short sentence that includes any DuckDB CLI version numbers the skill reported."
+
+    printf "  %-56s " "$desc"
+    t0=$(date +%s)
+    if ! run_codex "$prompt" "danger" "$output_file" "$log_file"; then
+        t1=$(date +%s)
+        elapsed=$((t1 - t0))
+        TIMINGS+=("$elapsed")
+        echo "FAIL  (${elapsed}s) - codex exec failed"
+        echo "        log: $(tail -n 5 "$log_file" 2>/dev/null | tr '\n' ' ')"
+        ((FAIL++))
+        return
+    fi
+    t1=$(date +%s)
+    elapsed=$((t1 - t0))
+    TIMINGS+=("$elapsed")
+
+    if grep -qE '[0-9]+\.[0-9]+\.[0-9]+' "$output_file"; then
+        echo "PASS  (${elapsed}s)"
+        ((PASS++))
+    else
+        echo "FAIL  (${elapsed}s) - no version number in output"
+        echo "        got: $(head -c 300 "$output_file" 2>/dev/null)"
+        ((FAIL++))
+    fi
+}
+
+trap cleanup EXIT
+
+if ! command -v "$CODEX_BIN" &>/dev/null; then
+    echo "ERROR: '${CODEX_BIN}' CLI not found."
+    exit 1
+fi
+if ! command -v duckdb &>/dev/null; then
+    echo "ERROR: 'duckdb' CLI not found."
+    exit 1
+fi
+if [ ! -d "$TARGET_HOME/.codex" ]; then
+    echo "ERROR: target Codex home not found at $TARGET_HOME/.codex"
+    echo "       Set TARGET_HOME to an initialized Codex home and retry."
+    exit 1
+fi
+
+require_plugin_smoke
+
+echo "=== install-duckdb skill eval (Codex) ==="
+echo "Plugin dir  : $PLUGIN_DIR"
+echo "Target home : $TARGET_HOME"
+echo "Temp logs   : $TMP_ROOT"
+echo ""
+
+echo "--- Single extension (core) ---"
+eval_install_case "Install httpfs"              "httpfs"                  httpfs
+eval_install_case "Install json"                "json"                    json
+
+echo ""
+echo "--- Extension with @repo ---"
+eval_install_case "Install gcs@community"       "gcs@community"           gcs
+
+echo ""
+echo "--- Multiple extensions ---"
+eval_install_case "Install spatial + httpfs"    "spatial httpfs"          spatial httpfs
+eval_install_case "Install spatial + gcs"       "spatial gcs@community"   spatial gcs
+
+echo ""
+echo "--- Update mode ---"
+eval_install_case "Update all extensions"       "--update"
+eval_install_case "Update specific extension"   "--update httpfs"
+
+echo ""
+echo "--- Version check (included in --update output) ---"
+eval_version_case "Version info present in --update output"
+
+echo ""
+total=0
+for t in "${TIMINGS[@]}"; do total=$((total + t)); done
+count=${#TIMINGS[@]}
+avg=$(( count > 0 ? total / count : 0 ))
+
+echo "=================================="
+echo "Results : $PASS passed, $FAIL failed"
+echo "Timing  : total ${total}s, avg ${avg}s per case"
+[ "$FAIL" -eq 0 ]

--- a/skills/install-duckdb/eval-codex.sh
+++ b/skills/install-duckdb/eval-codex.sh
@@ -16,7 +16,15 @@ KEEP_TEMP="${KEEP_TEMP:-0}"
 PASS=0
 FAIL=0
 TIMINGS=()
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/duckdb-skills-codex-eval.XXXXXX")"
+TMP_ROOT=""
+if ! TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/duckdb-skills-codex-eval.XXXXXX")"; then
+    echo "ERROR: failed to create temp directory for Codex eval." >&2
+    exit 1
+fi
+if [ ! -d "$TMP_ROOT" ]; then
+    echo "ERROR: temp directory was not created: $TMP_ROOT" >&2
+    exit 1
+fi
 
 cleanup() {
     if [ "$KEEP_TEMP" = "1" ]; then

--- a/skills/install-duckdb/eval-codex.sh
+++ b/skills/install-duckdb/eval-codex.sh
@@ -16,7 +16,7 @@ KEEP_TEMP="${KEEP_TEMP:-0}"
 PASS=0
 FAIL=0
 TIMINGS=()
-TMP_ROOT=$(mktemp -d /tmp/duckdb-skills-codex-eval.XXXXXX)
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/duckdb-skills-codex-eval.XXXXXX")"
 
 cleanup() {
     if [ "$KEEP_TEMP" = "1" ]; then

--- a/skills/install-duckdb/eval-codex.sh
+++ b/skills/install-duckdb/eval-codex.sh
@@ -6,13 +6,12 @@
 # duckdb-skills installed through /plugins and enabled in config.
 #
 # Usage:
-#   bash skills/install-duckdb/eval-codex.sh
 #   TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh
 #   KEEP_TEMP=1 TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh
 
 PLUGIN_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CODEX_BIN="${CODEX_BIN:-codex}"
-TARGET_HOME="${TARGET_HOME:-$HOME}"
+TARGET_HOME="${TARGET_HOME:-}"
 KEEP_TEMP="${KEEP_TEMP:-0}"
 PASS=0
 FAIL=0
@@ -157,6 +156,11 @@ eval_version_case() {
 
 trap cleanup EXIT
 
+if [ -z "$TARGET_HOME" ]; then
+    echo "ERROR: TARGET_HOME must point to an initialized Codex home."
+    echo "       Example: TARGET_HOME=/path/to/codex-home bash skills/install-duckdb/eval-codex.sh"
+    exit 1
+fi
 if ! command -v "$CODEX_BIN" &>/dev/null; then
     echo "ERROR: '${CODEX_BIN}' CLI not found."
     exit 1

--- a/skills/install-duckdb/eval.sh
+++ b/skills/install-duckdb/eval.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# End-to-end evaluations for the install-duckdb skill.
+# End-to-end evaluations for the install-duckdb skill via Claude Code.
 # Runs the skill via `claude --print` and verifies extensions are actually loadable.
+# For Codex coverage, use `bash skills/install-duckdb/eval-codex.sh`.
 #
 # Prerequisites: claude CLI and duckdb must be in PATH and claude must be authenticated.
 #
@@ -68,12 +69,12 @@ eval_case "Install json"               "json"                      json
 
 echo ""
 echo "--- Extension with @repo ---"
-eval_case "Install magic@community"    "magic@community"           magic
+eval_case "Install gcs@community"      "gcs@community"             gcs
 
 echo ""
 echo "--- Multiple extensions ---"
 eval_case "Install spatial + httpfs"   "spatial httpfs"            spatial httpfs
-eval_case "Install spatial + magic"    "spatial magic@community"   spatial magic
+eval_case "Install spatial + gcs"      "spatial gcs@community"     spatial gcs
 
 echo ""
 echo "--- Update mode ---"

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -46,7 +46,7 @@ If the state file exists but any ATTACH in it fails, warn the user and fall back
 command -v duckdb
 ```
 
-If not found, delegate to `/duckdb-skills:install-duckdb` and then continue.
+If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
 
 ## Step 3 — Generate SQL if needed
 
@@ -142,10 +142,10 @@ Always use heredocs (`<<'SQL'`) for multi-line queries to avoid shell quoting is
 ## Step 6 — Handle errors
 
 - **Syntax error**: show the error, suggest a corrected query, and re-run.
-- **Missing extension** (e.g. `Extension "X" not loaded`): delegate to `/duckdb-skills:install-duckdb <ext>`, then retry.
+- **Missing extension** (e.g. `Extension "X" not loaded`): delegate to `duckdb-skills:install-duckdb <ext>`, then retry.
 - **Table not found** (session mode): list available tables with `FROM duckdb_tables()` and suggest corrections.
 - **File not found** (ad-hoc mode): use `find "$PWD" -name "<filename>" 2>/dev/null` to locate the file and suggest the corrected path.
-- **Persistent or unclear DuckDB error**: use `/duckdb-skills:duckdb-docs <error message or relevant keywords>` to search the documentation for guidance, then apply the fix and retry.
+- **Persistent or unclear DuckDB error**: use `duckdb-skills:duckdb-docs <error message or relevant keywords>` to search the documentation for guidance, then apply the fix and retry.
 
 ## Step 7 — Present results
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -46,7 +46,7 @@ If the state file exists but any ATTACH in it fails, warn the user and fall back
 command -v duckdb
 ```
 
-If not found, delegate to `duckdb-skills:install-duckdb` and then continue.
+If not found, invoke the `install-duckdb` skill and then continue.
 
 ## Step 3 — Generate SQL if needed
 
@@ -142,10 +142,10 @@ Always use heredocs (`<<'SQL'`) for multi-line queries to avoid shell quoting is
 ## Step 6 — Handle errors
 
 - **Syntax error**: show the error, suggest a corrected query, and re-run.
-- **Missing extension** (e.g. `Extension "X" not loaded`): delegate to `duckdb-skills:install-duckdb <ext>`, then retry.
+- **Missing extension** (e.g. `Extension "X" not loaded`): invoke the `install-duckdb` skill for that extension, then retry.
 - **Table not found** (session mode): list available tables with `FROM duckdb_tables()` and suggest corrections.
 - **File not found** (ad-hoc mode): use `find "$PWD" -name "<filename>" 2>/dev/null` to locate the file and suggest the corrected path.
-- **Persistent or unclear DuckDB error**: use `duckdb-skills:duckdb-docs <error message or relevant keywords>` to search the documentation for guidance, then apply the fix and retry.
+- **Persistent or unclear DuckDB error**: use the `duckdb-docs` skill to search the documentation for guidance, then apply the fix and retry.
 
 ## Step 7 — Present results
 

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -70,7 +70,7 @@ FROM read_any('RESOLVED_PATH') LIMIT 20;
 ```
 
 **If this fails:**
-- **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb` and retry.
+- **`duckdb: command not found`** → invoke the `install-duckdb` skill and retry.
 - **Missing extension** (e.g. spatial files, xlsx, sqlite) → retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
 - **Wrong reader / parse error** → use the correct `read_*` function directly instead of `read_any`.
 

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -13,7 +13,7 @@ You are helping the user read and analyze a data file using DuckDB.
 Filename given: `$0`
 Question: `${1:-describe the data}`
 
-## Step 1 - Read it
+## Step 1 — Read it
 
 `RESOLVED_PATH` is `$0`. If the user gave a bare filename (no `/`), resolve it to a full path with `find` first.
 
@@ -70,11 +70,11 @@ FROM read_any('RESOLVED_PATH') LIMIT 20;
 ```
 
 **If this fails:**
-- **`duckdb: command not found`** -> invoke `/duckdb-skills:install-duckdb` and retry.
-- **Missing extension** (e.g. spatial files, xlsx, sqlite) -> retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
-- **Wrong reader / parse error** -> use the correct `read_*` function directly instead of `read_any`.
+- **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb` and retry.
+- **Missing extension** (e.g. spatial files, xlsx, sqlite) → retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
+- **Wrong reader / parse error** → use the correct `read_*` function directly instead of `read_any`.
 
-## Step 2 - Answer
+## Step 2 — Answer
 
 Using the schema, row count, and sample rows, answer:
 

--- a/skills/read-file/SKILL.md
+++ b/skills/read-file/SKILL.md
@@ -13,7 +13,7 @@ You are helping the user read and analyze a data file using DuckDB.
 Filename given: `$0`
 Question: `${1:-describe the data}`
 
-## Step 1 — Read it
+## Step 1 - Read it
 
 `RESOLVED_PATH` is `$0`. If the user gave a bare filename (no `/`), resolve it to a full path with `find` first.
 
@@ -70,11 +70,11 @@ FROM read_any('RESOLVED_PATH') LIMIT 20;
 ```
 
 **If this fails:**
-- **`duckdb: command not found`** → invoke `/duckdb-skills:install-duckdb` and retry.
-- **Missing extension** (e.g. spatial files, xlsx, sqlite) → retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
-- **Wrong reader / parse error** → use the correct `read_*` function directly instead of `read_any`.
+- **`duckdb: command not found`** -> invoke `/duckdb-skills:install-duckdb` and retry.
+- **Missing extension** (e.g. spatial files, xlsx, sqlite) -> retry with `INSTALL spatial; LOAD spatial;` or `INSTALL sqlite_scanner; LOAD sqlite_scanner;` prepended before the macro.
+- **Wrong reader / parse error** -> use the correct `read_*` function directly instead of `read_any`.
 
-## Step 2 — Answer
+## Step 2 - Answer
 
 Using the schema, row count, and sample rows, answer:
 

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -1,81 +1,54 @@
 ---
 name: read-memories
 description: >
-  Search past Codex or Claude Code session logs to recover your own context.
-  Invoke this proactively when you need to recall past decisions, patterns,
-  or unresolved work — either across all projects or scoped to the current one.
+  Search past Codex or Claude Code session logs to recall prior decisions, patterns, or unresolved
+  work. Use when user says "do you remember", "what did we do", references past conversations, or
+  you need context from prior sessions.
 argument-hint: <keyword> [--here]
 allowed-tools: Bash
 ---
 
-Use this to recover your own context from past sessions. Do NOT narrate the
-process to the user — silently run the query, absorb the results, and continue
+Search past session logs silently — do NOT narrate the process. Absorb the results and continue
 with enriched context.
 
-`$0` is the keyword to search for.
-Pass `--here` as a second argument (`$1`) to scope the search to the current project only.
+`$0` is the keyword. Pass `--here` as `$1` to scope to the current project only.
 
-## Step 1 — Discover available log sources and project scope
+## Step 1 — Choose the source
+
+- If `$0` is empty, stop and tell the user `read-memories` requires a non-empty keyword.
+- Claude Code search paths:
+  - All projects: `$HOME/.claude/projects/*/*.jsonl`
+  - Current only (`--here`): `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
+- Codex search path: `$HOME/.codex/sessions/*/*/*/*.jsonl`
+- For Codex `--here`, resolve `<PROJECT_ROOT>` with `git rev-parse --show-toplevel 2>/dev/null || echo "$PWD"` and filter rows with `project = '<PROJECT_ROOT>' OR starts_with(project, '<PROJECT_ROOT>/')`.
+
+## Step 2 — Query Claude Code
 
 ```bash
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
-WORKTREE_ROOTS="$PROJECT_ROOT"
-if git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  while IFS= read -r root; do
-    WORKTREE_ROOTS="${WORKTREE_ROOTS}"$'\n'"$root"
-  done < <(git -C "$PROJECT_ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
-fi
-WORKTREE_ROOTS="$(printf '%s\n' "$WORKTREE_ROOTS" | awk 'NF && !seen[$0]++')"
-HAS_CODEX=0
-HAS_CLAUDE=0
-find "$HOME/.codex/sessions" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && HAS_CODEX=1
-find "$HOME/.claude/projects" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && HAS_CLAUDE=1
-
-if [ -z "${0:-}" ]; then
-  echo "ERROR: read-memories requires a non-empty keyword." >&2
-  exit 1
-fi
-
-escape_sql_literal() {
-  printf '%s' "$1" | sed "s/'/''/g"
-}
-
-KEYWORD_SQL="$(escape_sql_literal "$0")"
-HOME_SQL="$(escape_sql_literal "$HOME")"
-
-CODEX_SCOPE_PREDICATE="1=1"
-CLAUDE_SCOPE_PREDICATE="1=1"
-if [ "$1" = "--here" ]; then
-  CODEX_SCOPE_PREDICATE=""
-  CLAUDE_SCOPE_PREDICATE=""
-  while IFS= read -r root; do
-    [ -z "$root" ] && continue
-    ROOT_SQL="$(escape_sql_literal "$root")"
-    CLAUDE_ID="$(echo "$root" | sed 's|[/_]|-|g')"
-    CLAUDE_ID_SQL="$(escape_sql_literal "$CLAUDE_ID")"
-    CODEX_SCOPE_PREDICATE="${CODEX_SCOPE_PREDICATE:+$CODEX_SCOPE_PREDICATE OR }(project = '$ROOT_SQL' OR starts_with(project, '$ROOT_SQL' || '/'))"
-    CLAUDE_SCOPE_PREDICATE="${CLAUDE_SCOPE_PREDICATE:+$CLAUDE_SCOPE_PREDICATE OR }(project = '$CLAUDE_ID_SQL')"
-  done <<EOF
-$WORKTREE_ROOTS
-EOF
-fi
+duckdb :memory: -c "
+SELECT
+  regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
+  strftime(timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
+  message.role AS role,
+  left(message.content::VARCHAR, 500) AS content
+FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
+WHERE message.content IS NOT NULL
+  AND contains(lower(message.content::VARCHAR), lower('<KEYWORD>'))
+  AND message.role IS NOT NULL
+ORDER BY timestamp
+LIMIT 40;
+"
 ```
 
-- If both `HAS_CODEX` and `HAS_CLAUDE` are `0`, tell the user no session logs were found and stop.
-- If `$0` is empty, tell the user `read-memories` requires a non-empty keyword and stop.
-- If `$1` is `--here`, keep Codex results scoped to `PROJECT_ROOT`, sibling worktrees in the same repository, and descendant directories of those roots.
-- For Claude Code, scope `--here` to exact project-root and sibling-worktree slugs only. Claude stores a lossy slugged project id, so descendant-directory matching is not reliable there.
-- If both sources are available, prefer the current client when it clearly answers the question; otherwise search both and merge the findings mentally.
-- If `HAS_CODEX` is `1`, run Step 2. Otherwise skip directly to Step 3.
-- If `HAS_CLAUDE` is `1`, run Step 3. Otherwise skip it.
+Replace `<SEARCH_PATH>` and `<KEYWORD>` before running.
 
-## Step 2 — Query Codex sessions (preview first, if available)
+## Step 3 — Query Codex
 
 ```bash
 duckdb :memory: -c "
 WITH raw AS (
   SELECT filename, timestamp, type, payload
-  FROM read_ndjson('${HOME_SQL}/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+  FROM read_ndjson('$HOME/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
 ),
 meta AS (
   SELECT filename, json_extract_string(payload, '$.cwd') AS project
@@ -84,7 +57,6 @@ meta AS (
 ),
 messages AS (
   SELECT
-    filename,
     COALESCE(meta.project, '(unknown)') AS project,
     strftime(raw.timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
     json_extract_string(raw.payload, '$.role') AS role,
@@ -101,113 +73,19 @@ SELECT
   project,
   ts,
   role,
-  length(content) AS content_chars,
-  CASE
-    WHEN length(content) > 240 THEN left(content, 240) || '...'
-    ELSE content
-  END AS preview
+  left(content, 500) AS content
 FROM messages
-WHERE '${KEYWORD_SQL}' <> ''
-  AND contains(lower(content), lower('${KEYWORD_SQL}'))
-  AND (${CODEX_SCOPE_PREDICATE})
-ORDER BY ts DESC
-LIMIT 20;
+WHERE contains(lower(content), lower('<KEYWORD>'))
+  AND <CODEX_SCOPE_PREDICATE>
+ORDER BY ts
+LIMIT 40;
 "
 ```
 
-This first pass intentionally returns bounded previews only. If the previews are enough, continue to
-Step 5. If you need the full message bodies or there are too many relevant hits to inspect safely in
-the conversation, use Step 4 instead of widening this SELECT in place.
+Replace `<KEYWORD>` before running. Use `1=1` for all projects, or use the `--here` predicate from
+Step 1 for `<CODEX_SCOPE_PREDICATE>`.
 
-## Step 3 — Query Claude Code sessions (preview first, if available)
+## Step 4 — Internalize
 
-```bash
-duckdb :memory: -c "
-SELECT
-  regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
-  strftime(timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
-  message.role AS role,
-  length(message.content::VARCHAR) AS content_chars,
-  CASE
-    WHEN length(message.content::VARCHAR) > 240 THEN left(message.content::VARCHAR, 240) || '...'
-    ELSE message.content::VARCHAR
-  END AS preview
-FROM read_ndjson('${HOME_SQL}/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
-WHERE '${KEYWORD_SQL}' <> ''
-  AND message.content IS NOT NULL
-  AND contains(lower(message.content::VARCHAR), lower('${KEYWORD_SQL}'))
-  AND message.role IS NOT NULL
-  AND (${CLAUDE_SCOPE_PREDICATE})
-ORDER BY timestamp DESC
-LIMIT 20;
-"
-```
-
-If both Codex and Claude Code logs exist, run both source queries and merge the relevant findings.
-
-## Step 4 — Handle large result sets
-
-If a source has many matches, or the preview rows above are not enough to answer the question,
-offload the full results to a temporary DuckDB file so you can query them interactively without
-flooding the conversation context:
-
-Resolve the state directory first:
-
-```bash
-STATE_DIR=""
-test -d .duckdb-skills && STATE_DIR=".duckdb-skills"
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
-PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
-test -d "$HOME/.duckdb-skills/$PROJECT_ID" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
-# Fall back to project-local if neither exists
-test -z "$STATE_DIR" && STATE_DIR=".duckdb-skills" && mkdir -p "$STATE_DIR"
-```
-
-Create the table using the same source query body you used above, but materialize full `content`
-into a common schema instead of the preview-only columns:
-
-```bash
-duckdb "$STATE_DIR/memories.duckdb" -c "
-CREATE OR REPLACE TABLE memories AS
-SELECT
-  '<SOURCE>' AS source,
-  project,
-  ts::TIMESTAMPTZ AS ts,
-  role,
-  content
-FROM (
-  <SOURCE_QUERY_BODY>
-);
-"
-```
-
-Replace `<SOURCE>` with `codex` or `claude`, and `<SOURCE_QUERY_BODY>` with the SELECT body from
-the source query you actually used.
-
-Then query the table interactively to drill down:
-
-```bash
-duckdb "$STATE_DIR/memories.duckdb" -c "SELECT count() FROM memories;"
-duckdb "$STATE_DIR/memories.duckdb" -c "FROM memories WHERE contains(lower(content), lower('<narrower term>')) LIMIT 20;"
-```
-
-Clean up when done:
-
-```bash
-rm -f "$STATE_DIR/memories.duckdb"
-```
-
-## Step 5 — Internalize
-
-From the results, extract:
-- Decisions made and their rationale
-- Patterns and conventions established
-- Unresolved items or open TODOs
-- Any corrections the user made to your prior behavior
-
-Use this to inform your current response. Do not repeat back the raw logs to the user.
-
-## Cross-skill integration
-
-- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
-- **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use the `duckdb-docs` skill to search for guidance.
+From the results, extract decisions, patterns, unresolved TODOs, and user corrections. Use this to
+inform your current response — do not repeat raw logs to the user.

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -1,17 +1,125 @@
 ---
 name: read-memories
 description: >
-  Search past Claude Code session logs to recall prior decisions, patterns, or unresolved work.
-  Use when user says "do you remember", "what did we do", references past conversations, or you need context from prior sessions.
+  Search past Codex or Claude Code session logs to recover your own context.
+  Invoke this proactively when you need to recall past decisions, patterns,
+  or unresolved work - either across all projects or scoped to the current one.
 argument-hint: <keyword> [--here]
 allowed-tools: Bash
 ---
 
-Search past session logs silently — do NOT narrate the process. Absorb the results and continue with enriched context.
+Use this to recover your own context from past sessions. Do NOT narrate the
+process to the user - silently run the query, absorb the results, and continue
+with enriched context.
 
-`$0` is the keyword. Pass `--here` as `$1` to scope to the current project only.
+`$0` is the keyword to search for.
+Pass `--here` as a second argument (`$1`) to scope the search to the current project only.
 
-## Step 1 — Query
+## Step 1 - Discover available log sources and project scope
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+WORKTREE_ROOTS="$PROJECT_ROOT"
+if git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  while IFS= read -r root; do
+    WORKTREE_ROOTS="${WORKTREE_ROOTS}"$'\n'"$root"
+  done < <(git -C "$PROJECT_ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
+fi
+WORKTREE_ROOTS="$(printf '%s\n' "$WORKTREE_ROOTS" | awk 'NF && !seen[$0]++')"
+HAS_CODEX=0
+HAS_CLAUDE=0
+find "$HOME/.codex/sessions" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && HAS_CODEX=1
+find "$HOME/.claude/projects" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && HAS_CLAUDE=1
+
+if [ -z "${0:-}" ]; then
+  echo "ERROR: read-memories requires a non-empty keyword." >&2
+  exit 1
+fi
+
+escape_sql_literal() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+KEYWORD_SQL="$(escape_sql_literal "$0")"
+HOME_SQL="$(escape_sql_literal "$HOME")"
+
+CODEX_SCOPE_PREDICATE="1=1"
+CLAUDE_SCOPE_PREDICATE="1=1"
+if [ "$1" = "--here" ]; then
+  CODEX_SCOPE_PREDICATE=""
+  CLAUDE_SCOPE_PREDICATE=""
+  while IFS= read -r root; do
+    [ -z "$root" ] && continue
+    ROOT_SQL="$(escape_sql_literal "$root")"
+    CLAUDE_ID="$(echo "$root" | sed 's|[/_]|-|g')"
+    CLAUDE_ID_SQL="$(escape_sql_literal "$CLAUDE_ID")"
+    CODEX_SCOPE_PREDICATE="${CODEX_SCOPE_PREDICATE:+$CODEX_SCOPE_PREDICATE OR }(project = '$ROOT_SQL' OR starts_with(project, '$ROOT_SQL' || '/'))"
+    CLAUDE_SCOPE_PREDICATE="${CLAUDE_SCOPE_PREDICATE:+$CLAUDE_SCOPE_PREDICATE OR }(project = '$CLAUDE_ID_SQL')"
+  done <<EOF
+$WORKTREE_ROOTS
+EOF
+fi
+```
+
+- If both `HAS_CODEX` and `HAS_CLAUDE` are `0`, tell the user no session logs were found and stop.
+- If `$0` is empty, tell the user `read-memories` requires a non-empty keyword and stop.
+- If `$1` is `--here`, keep Codex results scoped to `PROJECT_ROOT`, sibling worktrees in the same repository, and descendant directories of those roots.
+- For Claude Code, scope `--here` to exact project-root and sibling-worktree slugs only. Claude stores a lossy slugged project id, so descendant-directory matching is not reliable there.
+- If both sources are available, prefer the current client when it clearly answers the question; otherwise search both and merge the findings mentally.
+- If `HAS_CODEX` is `1`, run Step 2. Otherwise skip directly to Step 3.
+- If `HAS_CLAUDE` is `1`, run Step 3. Otherwise skip it.
+
+## Step 2 - Query Codex sessions (preview first, if available)
+
+```bash
+duckdb :memory: -c "
+WITH raw AS (
+  SELECT filename, timestamp, type, payload
+  FROM read_ndjson('${HOME_SQL}/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+),
+meta AS (
+  SELECT filename, json_extract_string(payload, '$.cwd') AS project
+  FROM raw
+  WHERE type = 'session_meta'
+),
+messages AS (
+  SELECT
+    filename,
+    COALESCE(meta.project, '(unknown)') AS project,
+    strftime(raw.timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
+    json_extract_string(raw.payload, '$.role') AS role,
+    string_agg(json_extract_string(chunk.value, '$.text'), '' ORDER BY CAST(chunk.key AS INTEGER)) AS content
+  FROM raw
+  LEFT JOIN meta USING (filename)
+  CROSS JOIN json_each(raw.payload, '$.content') AS chunk
+  WHERE raw.type = 'response_item'
+    AND json_extract_string(raw.payload, '$.role') IN ('user', 'assistant')
+    AND json_extract_string(chunk.value, '$.text') IS NOT NULL
+  GROUP BY ALL
+)
+SELECT
+  project,
+  ts,
+  role,
+  length(content) AS content_chars,
+  CASE
+    WHEN length(content) > 240 THEN left(content, 240) || '...'
+    ELSE content
+  END AS preview
+FROM messages
+WHERE '${KEYWORD_SQL}' <> ''
+  AND contains(lower(content), lower('${KEYWORD_SQL}'))
+  AND (${CODEX_SCOPE_PREDICATE})
+ORDER BY ts DESC
+LIMIT 20;
+"
+```
+
+This first pass intentionally returns bounded previews only. If the previews are enough, continue to
+Step 5. If you need the full message bodies or there are too many relevant hits to inspect safely in
+the conversation, use Step 4 instead of widening this SELECT in place.
+
+## Step 3 - Query Claude Code sessions (preview first, if available)
 
 ```bash
 duckdb :memory: -c "
@@ -19,21 +127,87 @@ SELECT
   regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
   strftime(timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
   message.role AS role,
-  left(message.content::VARCHAR, 500) AS content
-FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
-WHERE message::VARCHAR ILIKE '%<KEYWORD>%'
+  length(message.content::VARCHAR) AS content_chars,
+  CASE
+    WHEN length(message.content::VARCHAR) > 240 THEN left(message.content::VARCHAR, 240) || '...'
+    ELSE message.content::VARCHAR
+  END AS preview
+FROM read_ndjson('${HOME_SQL}/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+WHERE '${KEYWORD_SQL}' <> ''
+  AND message.content IS NOT NULL
+  AND contains(lower(message.content::VARCHAR), lower('${KEYWORD_SQL}'))
   AND message.role IS NOT NULL
-ORDER BY timestamp
-LIMIT 40;
+  AND (${CLAUDE_SCOPE_PREDICATE})
+ORDER BY timestamp DESC
+LIMIT 20;
 "
 ```
 
-Search paths:
-- All projects: `$HOME/.claude/projects/*/*.jsonl`
-- Current only (`--here`): `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
+If both Codex and Claude Code logs exist, run both source queries and merge the relevant findings.
 
-Replace `<SEARCH_PATH>` and `<KEYWORD>` before running.
+## Step 4 - Handle large result sets
 
-## Step 2 — Internalize
+If a source has many matches, or the preview rows above are not enough to answer the question,
+offload the full results to a temporary DuckDB file so you can query them interactively without
+flooding the conversation context:
 
-From the results, extract decisions, patterns, unresolved TODOs, and user corrections. Use this to inform your current response — do not repeat raw logs to the user.
+Resolve the state directory first:
+
+```bash
+STATE_DIR=""
+test -d .duckdb-skills && STATE_DIR=".duckdb-skills"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -d "$HOME/.duckdb-skills/$PROJECT_ID" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
+# Fall back to project-local if neither exists
+test -z "$STATE_DIR" && STATE_DIR=".duckdb-skills" && mkdir -p "$STATE_DIR"
+```
+
+Create the table using the same source query body you used above, but materialize full `content`
+into a common schema instead of the preview-only columns:
+
+```bash
+duckdb "$STATE_DIR/memories.duckdb" -c "
+CREATE OR REPLACE TABLE memories AS
+SELECT
+  '<SOURCE>' AS source,
+  project,
+  ts::TIMESTAMPTZ AS ts,
+  role,
+  content
+FROM (
+  <SOURCE_QUERY_BODY>
+);
+"
+```
+
+Replace `<SOURCE>` with `codex` or `claude`, and `<SOURCE_QUERY_BODY>` with the SELECT body from
+the source query you actually used.
+
+Then query the table interactively to drill down:
+
+```bash
+duckdb "$STATE_DIR/memories.duckdb" -c "SELECT count() FROM memories;"
+duckdb "$STATE_DIR/memories.duckdb" -c "FROM memories WHERE contains(lower(content), lower('<narrower term>')) LIMIT 20;"
+```
+
+Clean up when done:
+
+```bash
+rm -f "$STATE_DIR/memories.duckdb"
+```
+
+## Step 5 - Internalize
+
+From the results, extract:
+- Decisions made and their rationale
+- Patterns and conventions established
+- Unresolved items or open TODOs
+- Any corrections the user made to your prior behavior
+
+Use this to inform your current response. Do not repeat back the raw logs to the user.
+
+## Cross-skill integration
+
+- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it - useful if the user wants to cross-reference memories with their data.
+- **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use the `duckdb-docs` skill to search for guidance.

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -21,6 +21,7 @@ with enriched context.
   - Current only (`--here`): `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
 - Codex search path: `$HOME/.codex/sessions/*/*/*/*.jsonl`
 - For Codex `--here`, resolve `<PROJECT_ROOT>` with `git rev-parse --show-toplevel 2>/dev/null || echo "$PWD"` and filter rows with `project = '<PROJECT_ROOT>' OR starts_with(project, '<PROJECT_ROOT>/')`.
+- Before substituting `<SEARCH_PATH>`, `<KEYWORD>`, or `<PROJECT_ROOT>` into SQL string literals, escape single quotes by doubling them.
 
 ## Step 2 — Query Claude Code
 

--- a/skills/read-memories/SKILL.md
+++ b/skills/read-memories/SKILL.md
@@ -3,19 +3,19 @@ name: read-memories
 description: >
   Search past Codex or Claude Code session logs to recover your own context.
   Invoke this proactively when you need to recall past decisions, patterns,
-  or unresolved work - either across all projects or scoped to the current one.
+  or unresolved work — either across all projects or scoped to the current one.
 argument-hint: <keyword> [--here]
 allowed-tools: Bash
 ---
 
 Use this to recover your own context from past sessions. Do NOT narrate the
-process to the user - silently run the query, absorb the results, and continue
+process to the user — silently run the query, absorb the results, and continue
 with enriched context.
 
 `$0` is the keyword to search for.
 Pass `--here` as a second argument (`$1`) to scope the search to the current project only.
 
-## Step 1 - Discover available log sources and project scope
+## Step 1 — Discover available log sources and project scope
 
 ```bash
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
@@ -69,7 +69,7 @@ fi
 - If `HAS_CODEX` is `1`, run Step 2. Otherwise skip directly to Step 3.
 - If `HAS_CLAUDE` is `1`, run Step 3. Otherwise skip it.
 
-## Step 2 - Query Codex sessions (preview first, if available)
+## Step 2 — Query Codex sessions (preview first, if available)
 
 ```bash
 duckdb :memory: -c "
@@ -119,7 +119,7 @@ This first pass intentionally returns bounded previews only. If the previews are
 Step 5. If you need the full message bodies or there are too many relevant hits to inspect safely in
 the conversation, use Step 4 instead of widening this SELECT in place.
 
-## Step 3 - Query Claude Code sessions (preview first, if available)
+## Step 3 — Query Claude Code sessions (preview first, if available)
 
 ```bash
 duckdb :memory: -c "
@@ -145,7 +145,7 @@ LIMIT 20;
 
 If both Codex and Claude Code logs exist, run both source queries and merge the relevant findings.
 
-## Step 4 - Handle large result sets
+## Step 4 — Handle large result sets
 
 If a source has many matches, or the preview rows above are not enough to answer the question,
 offload the full results to a temporary DuckDB file so you can query them interactively without
@@ -197,7 +197,7 @@ Clean up when done:
 rm -f "$STATE_DIR/memories.duckdb"
 ```
 
-## Step 5 - Internalize
+## Step 5 — Internalize
 
 From the results, extract:
 - Decisions made and their rationale
@@ -209,5 +209,5 @@ Use this to inform your current response. Do not repeat back the raw logs to the
 
 ## Cross-skill integration
 
-- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it - useful if the user wants to cross-reference memories with their data.
+- **Session state**: If a `state.sql` exists (in `.duckdb-skills/` or `$HOME/.duckdb-skills/<project-id>/`), you can add the memories table to the session temporarily by appending an ATTACH to it — useful if the user wants to cross-reference memories with their data.
 - **Error troubleshooting**: If DuckDB returns errors when reading JSONL logs, use the `duckdb-docs` skill to search for guidance.

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -107,7 +107,7 @@ EOF
 
 query_codex_projects() {
     local predicate="$1"
-    local keyword="${2:-needle}"
+    local keyword="${2-needle}"
     local keyword_sql
 
     keyword_sql="$(escape_sql_literal "$keyword")"
@@ -133,7 +133,8 @@ messages AS (
 )
 SELECT project
 FROM messages
-WHERE content ILIKE '%' || '${keyword_sql}' || '%'
+WHERE '${keyword_sql}' <> ''
+  AND content ILIKE '%' || '${keyword_sql}' || '%'
   AND ($predicate)
 ORDER BY project;
 SQL
@@ -141,7 +142,7 @@ SQL
 
 query_claude_projects() {
     local predicate="$1"
-    local keyword="${2:-needle}"
+    local keyword="${2-needle}"
     local keyword_sql
 
     keyword_sql="$(escape_sql_literal "$keyword")"
@@ -149,7 +150,8 @@ query_claude_projects() {
     HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
 SELECT regexp_extract(filename, 'projects/([^/]+)/', 1) AS project
 FROM read_ndjson('$TEST_HOME/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
-WHERE message::VARCHAR ILIKE '%' || '${keyword_sql}' || '%'
+WHERE '${keyword_sql}' <> ''
+  AND message::VARCHAR ILIKE '%' || '${keyword_sql}' || '%'
   AND message.role IS NOT NULL
   AND ($predicate)
 ORDER BY project;
@@ -285,6 +287,26 @@ if [ "$CLAUDE_QUOTED_PATH_PROJECTS" != "$EXPECTED_CLAUDE_QUOTED_PATH" ]; then
     printf '%s\n' "$EXPECTED_CLAUDE_QUOTED_PATH"
     echo "Got:"
     printf '%s\n' "$CLAUDE_QUOTED_PATH_PROJECTS"
+    exit 1
+fi
+
+EMPTY_KEYWORD_CODEX="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" "" | normalize_project_rows)"
+
+if [ -n "$EMPTY_KEYWORD_CODEX" ]; then
+    echo "ERROR: Codex query matched rows for an empty keyword"
+    echo "Expected no matches"
+    echo "Got:"
+    printf '%s\n' "$EMPTY_KEYWORD_CODEX"
+    exit 1
+fi
+
+EMPTY_KEYWORD_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" "" | normalize_project_rows)"
+
+if [ -n "$EMPTY_KEYWORD_CLAUDE" ]; then
+    echo "ERROR: Claude query matched rows for an empty keyword"
+    echo "Expected no matches"
+    echo "Got:"
+    printf '%s\n' "$EMPTY_KEYWORD_CLAUDE"
     exit 1
 fi
 

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -71,26 +71,12 @@ build_codex_scope_predicate() {
 
 build_claude_scope_predicate() {
     local cwd="$1"
-    local project_root
-    local predicate=""
+    local slug
+    local slug_sql
 
-    project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")"
-
-    while IFS= read -r root; do
-        local slug slug_sql
-        [ -z "$root" ] && continue
-        slug="$(slugify_project "$root")"
-        slug_sql="$(escape_sql_literal "$slug")"
-        [ -n "$predicate" ] && predicate="$predicate OR "
-        predicate="${predicate}(project = '${slug_sql}')"
-    done < <(
-        {
-            printf '%s\n' "$project_root"
-            git -C "$project_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}'
-        } | awk '!seen[$0]++'
-    )
-
-    printf '%s\n' "${predicate:-FALSE}"
+    slug="$(slugify_project "$cwd")"
+    slug_sql="$(escape_sql_literal "$slug")"
+    printf "(project = '%s')\n" "$slug_sql"
 }
 
 write_codex_session() {
@@ -287,10 +273,10 @@ if [ "$CODEX_PROJECTS" != "$EXPECTED_CODEX" ]; then
 fi
 
 CLAUDE_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" | normalize_project_rows)"
-EXPECTED_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")" "$(slugify_project "$REPO_WORKTREE")" | sort)"
+EXPECTED_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_SUBDIR")")"
 
 if [ "$CLAUDE_PROJECTS" != "$EXPECTED_CLAUDE" ]; then
-    echo "ERROR: Claude --here scope did not keep the expected exact project/worktree matches"
+    echo "ERROR: Claude --here scope did not keep the expected exact current-project match"
     echo "Expected:"
     printf '%s\n' "$EXPECTED_CLAUDE"
     echo "Got:"
@@ -409,7 +395,7 @@ fi
 
 mv "$TEST_HOME/.codex" "$TEST_HOME/.codex.off"
 CLAUDE_ONLY_AVAILABLE="$(query_available_sources "$REPO_SUBDIR" | sort)"
-EXPECTED_CLAUDE_ONLY_AVAILABLE="$(printf 'claude,%s\n' "$(slugify_project "$REPO_MAIN")" "$(slugify_project "$REPO_WORKTREE")" | sort)"
+EXPECTED_CLAUDE_ONLY_AVAILABLE="$(printf 'claude,%s\n' "$(slugify_project "$REPO_SUBDIR")")"
 mv "$TEST_HOME/.codex.off" "$TEST_HOME/.codex"
 
 if [ "$CLAUDE_ONLY_AVAILABLE" != "$EXPECTED_CLAUDE_ONLY_AVAILABLE" ]; then
@@ -453,7 +439,7 @@ if [ "$LITERAL_PERCENT_CODEX" != "$EXPECTED_LITERAL_PERCENT_CODEX" ]; then
     exit 1
 fi
 
-LITERAL_PERCENT_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" "100%" | normalize_project_rows)"
+LITERAL_PERCENT_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_MAIN")" "100%" | normalize_project_rows)"
 EXPECTED_LITERAL_PERCENT_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")")"
 
 if [ "$LITERAL_PERCENT_CLAUDE" != "$EXPECTED_LITERAL_PERCENT_CLAUDE" ]; then
@@ -465,7 +451,7 @@ if [ "$LITERAL_PERCENT_CLAUDE" != "$EXPECTED_LITERAL_PERCENT_CLAUDE" ]; then
     exit 1
 fi
 
-ASSISTANT_FALSE_POSITIVE_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" "assistant" | normalize_project_rows)"
+ASSISTANT_FALSE_POSITIVE_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_MAIN")" "assistant" | normalize_project_rows)"
 
 if [ -n "$ASSISTANT_FALSE_POSITIVE_CLAUDE" ]; then
     echo "ERROR: Claude query matched role metadata instead of message content"
@@ -475,4 +461,4 @@ if [ -n "$ASSISTANT_FALSE_POSITIVE_CLAUDE" ]; then
     exit 1
 fi
 
-echo "PASS: read-memories --here keeps same-project roots and excludes unrelated repos"
+echo "PASS: read-memories --here keeps Codex repo scope, Claude current-project scope, and excludes unrelated repos"

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -12,6 +12,8 @@ REPO_UNDERSCORE_MAIN="$TMP_ROOT/my_repo"
 REPO_UNDERSCORE_SUBDIR="$REPO_UNDERSCORE_MAIN/subdir"
 REPO_UNDERSCORE_NEAR="$TMP_ROOT/myXrepo"
 REPO_UNDERSCORE_NEAR_SUBDIR="$REPO_UNDERSCORE_NEAR/subdir"
+REPO_QUOTE_MAIN="$TMP_ROOT/repo-o'hare"
+REPO_QUOTE_SUBDIR="$REPO_QUOTE_MAIN/subdir"
 CLAUDE_COLLISION_ROOT="$TMP_ROOT/foo-bar"
 CLAUDE_COLLISION_OTHER="$TMP_ROOT/foo/bar-baz"
 
@@ -30,6 +32,10 @@ slugify_project() {
     echo "$1" | sed 's|[/_]|-|g'
 }
 
+escape_sql_literal() {
+    printf '%s' "$1" | sed "s/'/''/g"
+}
+
 build_codex_scope_predicate() {
     local cwd="$1"
     local project_root
@@ -38,9 +44,11 @@ build_codex_scope_predicate() {
     project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")"
 
     while IFS= read -r root; do
+        local root_sql
         [ -z "$root" ] && continue
+        root_sql="$(escape_sql_literal "$root")"
         [ -n "$predicate" ] && predicate="$predicate OR "
-        predicate="${predicate}(project = '${root}' OR starts_with(project, '${root}' || '/'))"
+        predicate="${predicate}(project = '${root_sql}' OR starts_with(project, '${root_sql}' || '/'))"
     done < <(
         {
             printf '%s\n' "$project_root"
@@ -59,11 +67,12 @@ build_claude_scope_predicate() {
     project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")"
 
     while IFS= read -r root; do
-        local slug
+        local slug slug_sql
         [ -z "$root" ] && continue
         slug="$(slugify_project "$root")"
+        slug_sql="$(escape_sql_literal "$slug")"
         [ -n "$predicate" ] && predicate="$predicate OR "
-        predicate="${predicate}(project = '${slug}')"
+        predicate="${predicate}(project = '${slug_sql}')"
     done < <(
         {
             printf '%s\n' "$project_root"
@@ -98,6 +107,10 @@ EOF
 
 query_codex_projects() {
     local predicate="$1"
+    local keyword="${2:-needle}"
+    local keyword_sql
+
+    keyword_sql="$(escape_sql_literal "$keyword")"
 
     HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
 WITH raw AS (
@@ -120,7 +133,7 @@ messages AS (
 )
 SELECT project
 FROM messages
-WHERE content ILIKE '%needle%'
+WHERE content ILIKE '%' || '${keyword_sql}' || '%'
   AND ($predicate)
 ORDER BY project;
 SQL
@@ -128,20 +141,29 @@ SQL
 
 query_claude_projects() {
     local predicate="$1"
+    local keyword="${2:-needle}"
+    local keyword_sql
+
+    keyword_sql="$(escape_sql_literal "$keyword")"
 
     HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
 SELECT regexp_extract(filename, 'projects/([^/]+)/', 1) AS project
 FROM read_ndjson('$TEST_HOME/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
-WHERE message::VARCHAR ILIKE '%needle%'
+WHERE message::VARCHAR ILIKE '%' || '${keyword_sql}' || '%'
   AND message.role IS NOT NULL
   AND ($predicate)
 ORDER BY project;
 SQL
 }
 
+normalize_project_rows() {
+    tail -n +2 | sed 's/^"//; s/"$//'
+}
+
 mkdir -p "$TEST_HOME/.codex/sessions/2026/03/31" "$TEST_HOME/.claude/projects"
 mkdir -p "$REPO_MAIN" "$REPO_SUBDIR" "$UNRELATED_REPO"
 mkdir -p "$REPO_UNDERSCORE_MAIN" "$REPO_UNDERSCORE_SUBDIR" "$REPO_UNDERSCORE_NEAR_SUBDIR"
+mkdir -p "$REPO_QUOTE_MAIN" "$REPO_QUOTE_SUBDIR"
 mkdir -p "$CLAUDE_COLLISION_ROOT" "$CLAUDE_COLLISION_OTHER"
 
 git -C "$REPO_MAIN" init -q
@@ -152,6 +174,7 @@ git -C "$REPO_MAIN" add .gitignore
 git -C "$REPO_MAIN" commit -q -m "init"
 git -C "$REPO_MAIN" worktree add -q "$REPO_WORKTREE"
 git -C "$REPO_UNDERSCORE_MAIN" init -q
+git -C "$REPO_QUOTE_MAIN" init -q
 
 REPO_MAIN="$(cd "$REPO_MAIN" && pwd -P)"
 REPO_SUBDIR="$(cd "$REPO_SUBDIR" && pwd -P)"
@@ -161,6 +184,8 @@ REPO_UNDERSCORE_MAIN="$(cd "$REPO_UNDERSCORE_MAIN" && pwd -P)"
 REPO_UNDERSCORE_SUBDIR="$(cd "$REPO_UNDERSCORE_SUBDIR" && pwd -P)"
 REPO_UNDERSCORE_NEAR="$(cd "$REPO_UNDERSCORE_NEAR" && pwd -P)"
 REPO_UNDERSCORE_NEAR_SUBDIR="$(cd "$REPO_UNDERSCORE_NEAR_SUBDIR" && pwd -P)"
+REPO_QUOTE_MAIN="$(cd "$REPO_QUOTE_MAIN" && pwd -P)"
+REPO_QUOTE_SUBDIR="$(cd "$REPO_QUOTE_SUBDIR" && pwd -P)"
 CLAUDE_COLLISION_ROOT="$(cd "$CLAUDE_COLLISION_ROOT" && pwd -P)"
 CLAUDE_COLLISION_OTHER="$(cd "$CLAUDE_COLLISION_OTHER" && pwd -P)"
 
@@ -170,14 +195,17 @@ write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/worktree.jsonl" "$REP
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/unrelated.jsonl" "$UNRELATED_REPO" "needle unrelated"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-main-subdir.jsonl" "$REPO_UNDERSCORE_SUBDIR" "needle underscore main"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-near.jsonl" "$REPO_UNDERSCORE_NEAR_SUBDIR" "needle underscore near"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-keyword.jsonl" "$REPO_MAIN" "o'hare keyword"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-path.jsonl" "$REPO_QUOTE_SUBDIR" "needle quote path"
 
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/main.jsonl" "needle main"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_SUBDIR")/subdir.jsonl" "needle main subdir"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKTREE")/worktree.jsonl" "needle worktree"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$UNRELATED_REPO")/unrelated.jsonl" "needle unrelated"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_QUOTE_MAIN")/quoted-path.jsonl" "needle quote path"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$CLAUDE_COLLISION_OTHER")/collision.jsonl" "needle collision"
 
-CODEX_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" | tail -n +2)"
+CODEX_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" | normalize_project_rows)"
 EXPECTED_CODEX="$(printf '%s\n' "$REPO_MAIN" "$REPO_SUBDIR" "$REPO_WORKTREE" | sort)"
 
 if [ "$CODEX_PROJECTS" != "$EXPECTED_CODEX" ]; then
@@ -189,7 +217,7 @@ if [ "$CODEX_PROJECTS" != "$EXPECTED_CODEX" ]; then
     exit 1
 fi
 
-CLAUDE_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" | tail -n +2)"
+CLAUDE_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" | normalize_project_rows)"
 EXPECTED_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")" "$(slugify_project "$REPO_WORKTREE")" | sort)"
 
 if [ "$CLAUDE_PROJECTS" != "$EXPECTED_CLAUDE" ]; then
@@ -201,7 +229,7 @@ if [ "$CLAUDE_PROJECTS" != "$EXPECTED_CLAUDE" ]; then
     exit 1
 fi
 
-CLAUDE_COLLISION_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$CLAUDE_COLLISION_ROOT")" | tail -n +2)"
+CLAUDE_COLLISION_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$CLAUDE_COLLISION_ROOT")" | normalize_project_rows)"
 EXPECTED_CLAUDE_COLLISION=""
 
 if [ "$CLAUDE_COLLISION_PROJECTS" != "$EXPECTED_CLAUDE_COLLISION" ]; then
@@ -212,7 +240,7 @@ if [ "$CLAUDE_COLLISION_PROJECTS" != "$EXPECTED_CLAUDE_COLLISION" ]; then
     exit 1
 fi
 
-UNDERSCORE_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_UNDERSCORE_SUBDIR")" | tail -n +2)"
+UNDERSCORE_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_UNDERSCORE_SUBDIR")" | normalize_project_rows)"
 EXPECTED_UNDERSCORE="$(printf '%s\n' "$REPO_UNDERSCORE_SUBDIR")"
 
 if [ "$UNDERSCORE_PROJECTS" != "$EXPECTED_UNDERSCORE" ]; then
@@ -221,6 +249,42 @@ if [ "$UNDERSCORE_PROJECTS" != "$EXPECTED_UNDERSCORE" ]; then
     printf '%s\n' "$EXPECTED_UNDERSCORE"
     echo "Got:"
     printf '%s\n' "$UNDERSCORE_PROJECTS"
+    exit 1
+fi
+
+QUOTED_KEYWORD_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_MAIN")" "o'hare" | normalize_project_rows)"
+EXPECTED_QUOTED_KEYWORD="$(printf '%s\n' "$REPO_MAIN")"
+
+if [ "$QUOTED_KEYWORD_PROJECTS" != "$EXPECTED_QUOTED_KEYWORD" ]; then
+    echo "ERROR: Codex keyword search did not handle single quotes"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_QUOTED_KEYWORD"
+    echo "Got:"
+    printf '%s\n' "$QUOTED_KEYWORD_PROJECTS"
+    exit 1
+fi
+
+QUOTED_PATH_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_QUOTE_SUBDIR")" | normalize_project_rows)"
+EXPECTED_QUOTED_PATH="$(printf '%s\n' "$REPO_QUOTE_SUBDIR")"
+
+if [ "$QUOTED_PATH_PROJECTS" != "$EXPECTED_QUOTED_PATH" ]; then
+    echo "ERROR: Codex --here scope did not handle a quoted project path"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_QUOTED_PATH"
+    echo "Got:"
+    printf '%s\n' "$QUOTED_PATH_PROJECTS"
+    exit 1
+fi
+
+CLAUDE_QUOTED_PATH_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_QUOTE_MAIN")" | normalize_project_rows)"
+EXPECTED_CLAUDE_QUOTED_PATH="$(printf '%s\n' "$(slugify_project "$REPO_QUOTE_MAIN")")"
+
+if [ "$CLAUDE_QUOTED_PATH_PROJECTS" != "$EXPECTED_CLAUDE_QUOTED_PATH" ]; then
+    echo "ERROR: Claude --here scope did not handle a quoted project path"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_CLAUDE_QUOTED_PATH"
+    echo "Got:"
+    printf '%s\n' "$CLAUDE_QUOTED_PATH_PROJECTS"
     exit 1
 fi
 

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d /tmp/duckdb-skills-read-memories.XXXXXX)"
+TEST_HOME="$TMP_ROOT/home"
+REPO_MAIN="$TMP_ROOT/repo-main"
+REPO_SUBDIR="$REPO_MAIN/subdir"
+REPO_WORKTREE="$TMP_ROOT/repo-worktree"
+UNRELATED_REPO="$TMP_ROOT/unrelated"
+REPO_UNDERSCORE_MAIN="$TMP_ROOT/my_repo"
+REPO_UNDERSCORE_SUBDIR="$REPO_UNDERSCORE_MAIN/subdir"
+REPO_UNDERSCORE_NEAR="$TMP_ROOT/myXrepo"
+REPO_UNDERSCORE_NEAR_SUBDIR="$REPO_UNDERSCORE_NEAR/subdir"
+CLAUDE_COLLISION_ROOT="$TMP_ROOT/foo-bar"
+CLAUDE_COLLISION_OTHER="$TMP_ROOT/foo/bar-baz"
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+
+trap cleanup EXIT
+
+if ! command -v duckdb >/dev/null 2>&1; then
+    echo "ERROR: duckdb CLI not found."
+    exit 1
+fi
+
+slugify_project() {
+    echo "$1" | sed 's|[/_]|-|g'
+}
+
+build_codex_scope_predicate() {
+    local cwd="$1"
+    local project_root
+    local predicate=""
+
+    project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")"
+
+    while IFS= read -r root; do
+        [ -z "$root" ] && continue
+        [ -n "$predicate" ] && predicate="$predicate OR "
+        predicate="${predicate}(project = '${root}' OR starts_with(project, '${root}' || '/'))"
+    done < <(
+        {
+            printf '%s\n' "$project_root"
+            git -C "$project_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}'
+        } | awk '!seen[$0]++'
+    )
+
+    printf '%s\n' "${predicate:-FALSE}"
+}
+
+build_claude_scope_predicate() {
+    local cwd="$1"
+    local project_root
+    local predicate=""
+
+    project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")"
+
+    while IFS= read -r root; do
+        local slug
+        [ -z "$root" ] && continue
+        slug="$(slugify_project "$root")"
+        [ -n "$predicate" ] && predicate="$predicate OR "
+        predicate="${predicate}(project = '${slug}')"
+    done < <(
+        {
+            printf '%s\n' "$project_root"
+            git -C "$project_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}'
+        } | awk '!seen[$0]++'
+    )
+
+    printf '%s\n' "${predicate:-FALSE}"
+}
+
+write_codex_session() {
+    local file="$1"
+    local cwd="$2"
+    local content="$3"
+
+    mkdir -p "$(dirname "$file")"
+    cat >"$file" <<EOF
+{"timestamp":"2026-03-31T12:00:00Z","type":"session_meta","payload":{"cwd":"$cwd"}}
+{"timestamp":"2026-03-31T12:01:00Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"$content"}]}}
+EOF
+}
+
+write_claude_session() {
+    local file="$1"
+    local content="$2"
+
+    mkdir -p "$(dirname "$file")"
+    cat >"$file" <<EOF
+{"timestamp":"2026-03-31T12:00:00Z","message":{"role":"assistant","content":"$content"}}
+EOF
+}
+
+query_codex_projects() {
+    local predicate="$1"
+
+    HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
+WITH raw AS (
+  SELECT filename, timestamp, type, payload
+  FROM read_ndjson('$TEST_HOME/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+),
+meta AS (
+  SELECT filename, json_extract_string(payload, '$.cwd') AS project
+  FROM raw
+  WHERE type = 'session_meta'
+),
+messages AS (
+  SELECT
+    COALESCE(meta.project, '(unknown)') AS project,
+    json_extract_string(raw.payload, '$.content[0].text') AS content
+  FROM raw
+  LEFT JOIN meta USING (filename)
+  WHERE raw.type = 'response_item'
+    AND json_extract_string(raw.payload, '$.role') IN ('user', 'assistant')
+)
+SELECT project
+FROM messages
+WHERE content ILIKE '%needle%'
+  AND ($predicate)
+ORDER BY project;
+SQL
+}
+
+query_claude_projects() {
+    local predicate="$1"
+
+    HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
+SELECT regexp_extract(filename, 'projects/([^/]+)/', 1) AS project
+FROM read_ndjson('$TEST_HOME/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+WHERE message::VARCHAR ILIKE '%needle%'
+  AND message.role IS NOT NULL
+  AND ($predicate)
+ORDER BY project;
+SQL
+}
+
+mkdir -p "$TEST_HOME/.codex/sessions/2026/03/31" "$TEST_HOME/.claude/projects"
+mkdir -p "$REPO_MAIN" "$REPO_SUBDIR" "$UNRELATED_REPO"
+mkdir -p "$REPO_UNDERSCORE_MAIN" "$REPO_UNDERSCORE_SUBDIR" "$REPO_UNDERSCORE_NEAR_SUBDIR"
+mkdir -p "$CLAUDE_COLLISION_ROOT" "$CLAUDE_COLLISION_OTHER"
+
+git -C "$REPO_MAIN" init -q
+git -C "$REPO_MAIN" config user.email test@example.com
+git -C "$REPO_MAIN" config user.name "DuckDB Skills Eval"
+touch "$REPO_MAIN/.gitignore"
+git -C "$REPO_MAIN" add .gitignore
+git -C "$REPO_MAIN" commit -q -m "init"
+git -C "$REPO_MAIN" worktree add -q "$REPO_WORKTREE"
+git -C "$REPO_UNDERSCORE_MAIN" init -q
+
+REPO_MAIN="$(cd "$REPO_MAIN" && pwd -P)"
+REPO_SUBDIR="$(cd "$REPO_SUBDIR" && pwd -P)"
+REPO_WORKTREE="$(cd "$REPO_WORKTREE" && pwd -P)"
+UNRELATED_REPO="$(cd "$UNRELATED_REPO" && pwd -P)"
+REPO_UNDERSCORE_MAIN="$(cd "$REPO_UNDERSCORE_MAIN" && pwd -P)"
+REPO_UNDERSCORE_SUBDIR="$(cd "$REPO_UNDERSCORE_SUBDIR" && pwd -P)"
+REPO_UNDERSCORE_NEAR="$(cd "$REPO_UNDERSCORE_NEAR" && pwd -P)"
+REPO_UNDERSCORE_NEAR_SUBDIR="$(cd "$REPO_UNDERSCORE_NEAR_SUBDIR" && pwd -P)"
+CLAUDE_COLLISION_ROOT="$(cd "$CLAUDE_COLLISION_ROOT" && pwd -P)"
+CLAUDE_COLLISION_OTHER="$(cd "$CLAUDE_COLLISION_OTHER" && pwd -P)"
+
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/main-root.jsonl" "$REPO_MAIN" "needle main root"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/main-subdir.jsonl" "$REPO_SUBDIR" "needle main subdir"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/worktree.jsonl" "$REPO_WORKTREE" "needle worktree"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/unrelated.jsonl" "$UNRELATED_REPO" "needle unrelated"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-main-subdir.jsonl" "$REPO_UNDERSCORE_SUBDIR" "needle underscore main"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-near.jsonl" "$REPO_UNDERSCORE_NEAR_SUBDIR" "needle underscore near"
+
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/main.jsonl" "needle main"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_SUBDIR")/subdir.jsonl" "needle main subdir"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKTREE")/worktree.jsonl" "needle worktree"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$UNRELATED_REPO")/unrelated.jsonl" "needle unrelated"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$CLAUDE_COLLISION_OTHER")/collision.jsonl" "needle collision"
+
+CODEX_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" | tail -n +2)"
+EXPECTED_CODEX="$(printf '%s\n' "$REPO_MAIN" "$REPO_SUBDIR" "$REPO_WORKTREE" | sort)"
+
+if [ "$CODEX_PROJECTS" != "$EXPECTED_CODEX" ]; then
+    echo "ERROR: Codex --here scope did not include the expected same-project roots"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_CODEX"
+    echo "Got:"
+    printf '%s\n' "$CODEX_PROJECTS"
+    exit 1
+fi
+
+CLAUDE_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" | tail -n +2)"
+EXPECTED_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")" "$(slugify_project "$REPO_WORKTREE")" | sort)"
+
+if [ "$CLAUDE_PROJECTS" != "$EXPECTED_CLAUDE" ]; then
+    echo "ERROR: Claude --here scope did not keep the expected exact project/worktree matches"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_CLAUDE"
+    echo "Got:"
+    printf '%s\n' "$CLAUDE_PROJECTS"
+    exit 1
+fi
+
+CLAUDE_COLLISION_PROJECTS="$(query_claude_projects "$(build_claude_scope_predicate "$CLAUDE_COLLISION_ROOT")" | tail -n +2)"
+EXPECTED_CLAUDE_COLLISION=""
+
+if [ "$CLAUDE_COLLISION_PROJECTS" != "$EXPECTED_CLAUDE_COLLISION" ]; then
+    echo "ERROR: Claude --here scope matched a slug-collision path"
+    echo "Expected no matches"
+    echo "Got:"
+    printf '%s\n' "$CLAUDE_COLLISION_PROJECTS"
+    exit 1
+fi
+
+UNDERSCORE_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_UNDERSCORE_SUBDIR")" | tail -n +2)"
+EXPECTED_UNDERSCORE="$(printf '%s\n' "$REPO_UNDERSCORE_SUBDIR")"
+
+if [ "$UNDERSCORE_PROJECTS" != "$EXPECTED_UNDERSCORE" ]; then
+    echo "ERROR: Codex --here scope overmatched an underscore-like path"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_UNDERSCORE"
+    echo "Got:"
+    printf '%s\n' "$UNDERSCORE_PROJECTS"
+    exit 1
+fi
+
+echo "PASS: read-memories --here keeps same-project roots and excludes unrelated repos"

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-TMP_ROOT="$(mktemp -d /tmp/duckdb-skills-read-memories.XXXXXX)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/duckdb-skills-read-memories.XXXXXX")"
 TEST_HOME="$TMP_ROOT/home-o'hare"
 REPO_MAIN="$TMP_ROOT/repo-main"
 REPO_SUBDIR="$REPO_MAIN/subdir"

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -108,6 +108,23 @@ write_codex_session() {
 EOF
 }
 
+write_codex_multichunk_session() {
+    local file="$1"
+    local cwd="$2"
+    local first_content="$3"
+    local second_content="$4"
+    local cwd_json first_json second_json
+
+    mkdir -p "$(dirname "$file")"
+    cwd_json="$(json_escape "$cwd")"
+    first_json="$(json_escape "$first_content")"
+    second_json="$(json_escape "$second_content")"
+    cat >"$file" <<EOF
+{"timestamp":"2026-03-31T12:00:00Z","type":"session_meta","payload":{"cwd":"$cwd_json"}}
+{"timestamp":"2026-03-31T12:01:00Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"input_text","text":"$first_json"},{"type":"input_text","text":"$second_json"}]}}
+EOF
+}
+
 write_claude_session() {
     local file="$1"
     local content="$2"
@@ -141,12 +158,17 @@ meta AS (
 ),
 messages AS (
   SELECT
+    filename,
     COALESCE(meta.project, '(unknown)') AS project,
-    json_extract_string(raw.payload, '$.content[0].text') AS content
+    json_extract_string(raw.payload, '$.role') AS role,
+    string_agg(json_extract_string(chunk.value, '$.text'), '' ORDER BY CAST(chunk.key AS INTEGER)) AS content
   FROM raw
   LEFT JOIN meta USING (filename)
+  CROSS JOIN json_each(raw.payload, '$.content') AS chunk
   WHERE raw.type = 'response_item'
     AND json_extract_string(raw.payload, '$.role') IN ('user', 'assistant')
+    AND json_extract_string(chunk.value, '$.text') IS NOT NULL
+  GROUP BY ALL
 )
 SELECT project
 FROM messages
@@ -155,6 +177,24 @@ WHERE '${keyword_sql}' <> ''
   AND ($predicate)
 ORDER BY project;
 SQL
+}
+
+query_available_sources() {
+    local cwd="$1"
+    local keyword="${2-needle}"
+    local has_codex=0
+    local has_claude=0
+
+    find "$TEST_HOME/.codex/sessions" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && has_codex=1
+    find "$TEST_HOME/.claude/projects" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q . && has_claude=1
+
+    if [ "$has_codex" -eq 1 ]; then
+        query_codex_projects "$(build_codex_scope_predicate "$cwd")" "$keyword" | normalize_project_rows | sed 's/^/codex,/'
+    fi
+
+    if [ "$has_claude" -eq 1 ]; then
+        query_claude_projects "$(build_claude_scope_predicate "$cwd")" "$keyword" | normalize_project_rows | sed 's/^/claude,/'
+    fi
 }
 
 query_claude_projects() {
@@ -179,7 +219,7 @@ SQL
 }
 
 normalize_project_rows() {
-    tail -n +2 | sed 's/^"//; s/"$//'
+    tail -n +2 | sed 's/^"//; s/"$//' | awk '!seen[$0]++'
 }
 
 mkdir -p "$TEST_HOME/.codex/sessions/2026/03/31" "$TEST_HOME/.claude/projects"
@@ -220,6 +260,7 @@ write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-near.jsonl
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-keyword.jsonl" "$REPO_MAIN" "o'hare keyword"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-path.jsonl" "$REPO_QUOTE_SUBDIR" "needle quote path"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-content.jsonl" "$REPO_MAIN" "double \"quote\" keyword"
+write_codex_multichunk_session "$TEST_HOME/.codex/sessions/2026/03/31/later-chunk.jsonl" "$REPO_MAIN" "prefix only" "needle later chunk"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/literal-percent.jsonl" "$REPO_MAIN" "100% literal"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/wildcard-percent.jsonl" "$REPO_WORKTREE" "100X broadening"
 
@@ -337,6 +378,46 @@ if [ "$DOUBLE_QUOTE_CLAUDE" != "$EXPECTED_DOUBLE_QUOTE_CLAUDE" ]; then
     printf '%s\n' "$EXPECTED_DOUBLE_QUOTE_CLAUDE"
     echo "Got:"
     printf '%s\n' "$DOUBLE_QUOTE_CLAUDE"
+    exit 1
+fi
+
+LATER_CHUNK_CODEX="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_MAIN")" "later chunk" | normalize_project_rows)"
+EXPECTED_LATER_CHUNK_CODEX="$(printf '%s\n' "$REPO_MAIN")"
+
+if [ "$LATER_CHUNK_CODEX" != "$EXPECTED_LATER_CHUNK_CODEX" ]; then
+    echo "ERROR: Codex query missed a keyword stored outside the first content chunk"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_LATER_CHUNK_CODEX"
+    echo "Got:"
+    printf '%s\n' "$LATER_CHUNK_CODEX"
+    exit 1
+fi
+
+mv "$TEST_HOME/.claude" "$TEST_HOME/.claude.off"
+CODEX_ONLY_AVAILABLE="$(query_available_sources "$REPO_SUBDIR" | sort)"
+EXPECTED_CODEX_ONLY_AVAILABLE="$(printf 'codex,%s\n' "$REPO_MAIN" "$REPO_SUBDIR" "$REPO_WORKTREE" | sort)"
+mv "$TEST_HOME/.claude.off" "$TEST_HOME/.claude"
+
+if [ "$CODEX_ONLY_AVAILABLE" != "$EXPECTED_CODEX_ONLY_AVAILABLE" ]; then
+    echo "ERROR: available-source query did not stay within Codex logs when Claude logs were absent"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_CODEX_ONLY_AVAILABLE"
+    echo "Got:"
+    printf '%s\n' "$CODEX_ONLY_AVAILABLE"
+    exit 1
+fi
+
+mv "$TEST_HOME/.codex" "$TEST_HOME/.codex.off"
+CLAUDE_ONLY_AVAILABLE="$(query_available_sources "$REPO_SUBDIR" | sort)"
+EXPECTED_CLAUDE_ONLY_AVAILABLE="$(printf 'claude,%s\n' "$(slugify_project "$REPO_MAIN")" "$(slugify_project "$REPO_WORKTREE")" | sort)"
+mv "$TEST_HOME/.codex.off" "$TEST_HOME/.codex"
+
+if [ "$CLAUDE_ONLY_AVAILABLE" != "$EXPECTED_CLAUDE_ONLY_AVAILABLE" ]; then
+    echo "ERROR: available-source query did not stay within Claude logs when Codex logs were absent"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_CLAUDE_ONLY_AVAILABLE"
+    echo "Got:"
+    printf '%s\n' "$CLAUDE_ONLY_AVAILABLE"
     exit 1
 fi
 

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 TMP_ROOT="$(mktemp -d /tmp/duckdb-skills-read-memories.XXXXXX)"
-TEST_HOME="$TMP_ROOT/home"
+TEST_HOME="$TMP_ROOT/home-o'hare"
 REPO_MAIN="$TMP_ROOT/repo-main"
 REPO_SUBDIR="$REPO_MAIN/subdir"
 REPO_WORKTREE="$TMP_ROOT/repo-worktree"
@@ -34,6 +34,16 @@ slugify_project() {
 
 escape_sql_literal() {
     printf '%s' "$1" | sed "s/'/''/g"
+}
+
+json_escape() {
+    local value="$1"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
 }
 
 build_codex_scope_predicate() {
@@ -87,21 +97,26 @@ write_codex_session() {
     local file="$1"
     local cwd="$2"
     local content="$3"
+    local cwd_json content_json
 
     mkdir -p "$(dirname "$file")"
+    cwd_json="$(json_escape "$cwd")"
+    content_json="$(json_escape "$content")"
     cat >"$file" <<EOF
-{"timestamp":"2026-03-31T12:00:00Z","type":"session_meta","payload":{"cwd":"$cwd"}}
-{"timestamp":"2026-03-31T12:01:00Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"$content"}]}}
+{"timestamp":"2026-03-31T12:00:00Z","type":"session_meta","payload":{"cwd":"$cwd_json"}}
+{"timestamp":"2026-03-31T12:01:00Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"$content_json"}]}}
 EOF
 }
 
 write_claude_session() {
     local file="$1"
     local content="$2"
+    local content_json
 
     mkdir -p "$(dirname "$file")"
+    content_json="$(json_escape "$content")"
     cat >"$file" <<EOF
-{"timestamp":"2026-03-31T12:00:00Z","message":{"role":"assistant","content":"$content"}}
+{"timestamp":"2026-03-31T12:00:00Z","message":{"role":"assistant","content":"$content_json"}}
 EOF
 }
 
@@ -109,13 +124,15 @@ query_codex_projects() {
     local predicate="$1"
     local keyword="${2-needle}"
     local keyword_sql
+    local test_home_sql
 
     keyword_sql="$(escape_sql_literal "$keyword")"
+    test_home_sql="$(escape_sql_literal "$TEST_HOME")"
 
     HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
 WITH raw AS (
   SELECT filename, timestamp, type, payload
-  FROM read_ndjson('$TEST_HOME/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+  FROM read_ndjson('${test_home_sql}/.codex/sessions/*/*/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
 ),
 meta AS (
   SELECT filename, json_extract_string(payload, '$.cwd') AS project
@@ -144,14 +161,17 @@ query_claude_projects() {
     local predicate="$1"
     local keyword="${2-needle}"
     local keyword_sql
+    local test_home_sql
 
     keyword_sql="$(escape_sql_literal "$keyword")"
+    test_home_sql="$(escape_sql_literal "$TEST_HOME")"
 
     HOME="$TEST_HOME" duckdb :memory: -csv <<SQL
 SELECT regexp_extract(filename, 'projects/([^/]+)/', 1) AS project
-FROM read_ndjson('$TEST_HOME/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
+FROM read_ndjson('${test_home_sql}/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
 WHERE '${keyword_sql}' <> ''
-  AND contains(lower(message::VARCHAR), lower('${keyword_sql}'))
+  AND message.content IS NOT NULL
+  AND contains(lower(message.content::VARCHAR), lower('${keyword_sql}'))
   AND message.role IS NOT NULL
   AND ($predicate)
 ORDER BY project;
@@ -199,6 +219,7 @@ write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-main-subdi
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-near.jsonl" "$REPO_UNDERSCORE_NEAR_SUBDIR" "needle underscore near"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-keyword.jsonl" "$REPO_MAIN" "o'hare keyword"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-path.jsonl" "$REPO_QUOTE_SUBDIR" "needle quote path"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-content.jsonl" "$REPO_MAIN" "double \"quote\" keyword"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/literal-percent.jsonl" "$REPO_MAIN" "100% literal"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/wildcard-percent.jsonl" "$REPO_WORKTREE" "100X broadening"
 
@@ -208,6 +229,7 @@ write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKT
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$UNRELATED_REPO")/unrelated.jsonl" "needle unrelated"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_QUOTE_MAIN")/quoted-path.jsonl" "needle quote path"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$CLAUDE_COLLISION_OTHER")/collision.jsonl" "needle collision"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/quoted-content.jsonl" "double \"quote\" keyword"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/literal-percent.jsonl" "100% literal"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKTREE")/wildcard-percent.jsonl" "100X broadening"
 
@@ -294,6 +316,30 @@ if [ "$CLAUDE_QUOTED_PATH_PROJECTS" != "$EXPECTED_CLAUDE_QUOTED_PATH" ]; then
     exit 1
 fi
 
+DOUBLE_QUOTE_CODEX="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_MAIN")" 'double "quote"' | normalize_project_rows)"
+EXPECTED_DOUBLE_QUOTE_CODEX="$(printf '%s\n' "$REPO_MAIN")"
+
+if [ "$DOUBLE_QUOTE_CODEX" != "$EXPECTED_DOUBLE_QUOTE_CODEX" ]; then
+    echo "ERROR: Codex query did not preserve double quotes in JSON fixture content"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_DOUBLE_QUOTE_CODEX"
+    echo "Got:"
+    printf '%s\n' "$DOUBLE_QUOTE_CODEX"
+    exit 1
+fi
+
+DOUBLE_QUOTE_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_MAIN")" 'double "quote"' | normalize_project_rows)"
+EXPECTED_DOUBLE_QUOTE_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")")"
+
+if [ "$DOUBLE_QUOTE_CLAUDE" != "$EXPECTED_DOUBLE_QUOTE_CLAUDE" ]; then
+    echo "ERROR: Claude query did not preserve double quotes in JSON fixture content"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_DOUBLE_QUOTE_CLAUDE"
+    echo "Got:"
+    printf '%s\n' "$DOUBLE_QUOTE_CLAUDE"
+    exit 1
+fi
+
 EMPTY_KEYWORD_CODEX="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" "" | normalize_project_rows)"
 
 if [ -n "$EMPTY_KEYWORD_CODEX" ]; then
@@ -335,6 +381,16 @@ if [ "$LITERAL_PERCENT_CLAUDE" != "$EXPECTED_LITERAL_PERCENT_CLAUDE" ]; then
     printf '%s\n' "$EXPECTED_LITERAL_PERCENT_CLAUDE"
     echo "Got:"
     printf '%s\n' "$LITERAL_PERCENT_CLAUDE"
+    exit 1
+fi
+
+ASSISTANT_FALSE_POSITIVE_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" "assistant" | normalize_project_rows)"
+
+if [ -n "$ASSISTANT_FALSE_POSITIVE_CLAUDE" ]; then
+    echo "ERROR: Claude query matched role metadata instead of message content"
+    echo "Expected no matches"
+    echo "Got:"
+    printf '%s\n' "$ASSISTANT_FALSE_POSITIVE_CLAUDE"
     exit 1
 fi
 

--- a/skills/read-memories/eval.sh
+++ b/skills/read-memories/eval.sh
@@ -134,7 +134,7 @@ messages AS (
 SELECT project
 FROM messages
 WHERE '${keyword_sql}' <> ''
-  AND content ILIKE '%' || '${keyword_sql}' || '%'
+  AND contains(lower(content), lower('${keyword_sql}'))
   AND ($predicate)
 ORDER BY project;
 SQL
@@ -151,7 +151,7 @@ query_claude_projects() {
 SELECT regexp_extract(filename, 'projects/([^/]+)/', 1) AS project
 FROM read_ndjson('$TEST_HOME/.claude/projects/*/*.jsonl', auto_detect=true, ignore_errors=true, filename=true)
 WHERE '${keyword_sql}' <> ''
-  AND message::VARCHAR ILIKE '%' || '${keyword_sql}' || '%'
+  AND contains(lower(message::VARCHAR), lower('${keyword_sql}'))
   AND message.role IS NOT NULL
   AND ($predicate)
 ORDER BY project;
@@ -199,6 +199,8 @@ write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-main-subdi
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/underscore-near.jsonl" "$REPO_UNDERSCORE_NEAR_SUBDIR" "needle underscore near"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-keyword.jsonl" "$REPO_MAIN" "o'hare keyword"
 write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/quoted-path.jsonl" "$REPO_QUOTE_SUBDIR" "needle quote path"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/literal-percent.jsonl" "$REPO_MAIN" "100% literal"
+write_codex_session "$TEST_HOME/.codex/sessions/2026/03/31/wildcard-percent.jsonl" "$REPO_WORKTREE" "100X broadening"
 
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/main.jsonl" "needle main"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_SUBDIR")/subdir.jsonl" "needle main subdir"
@@ -206,6 +208,8 @@ write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKT
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$UNRELATED_REPO")/unrelated.jsonl" "needle unrelated"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_QUOTE_MAIN")/quoted-path.jsonl" "needle quote path"
 write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$CLAUDE_COLLISION_OTHER")/collision.jsonl" "needle collision"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_MAIN")/literal-percent.jsonl" "100% literal"
+write_claude_session "$TEST_HOME/.claude/projects/$(slugify_project "$REPO_WORKTREE")/wildcard-percent.jsonl" "100X broadening"
 
 CODEX_PROJECTS="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" | normalize_project_rows)"
 EXPECTED_CODEX="$(printf '%s\n' "$REPO_MAIN" "$REPO_SUBDIR" "$REPO_WORKTREE" | sort)"
@@ -307,6 +311,30 @@ if [ -n "$EMPTY_KEYWORD_CLAUDE" ]; then
     echo "Expected no matches"
     echo "Got:"
     printf '%s\n' "$EMPTY_KEYWORD_CLAUDE"
+    exit 1
+fi
+
+LITERAL_PERCENT_CODEX="$(query_codex_projects "$(build_codex_scope_predicate "$REPO_SUBDIR")" "100%" | normalize_project_rows)"
+EXPECTED_LITERAL_PERCENT_CODEX="$(printf '%s\n' "$REPO_MAIN")"
+
+if [ "$LITERAL_PERCENT_CODEX" != "$EXPECTED_LITERAL_PERCENT_CODEX" ]; then
+    echo "ERROR: Codex query treated % in the keyword as a wildcard"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_LITERAL_PERCENT_CODEX"
+    echo "Got:"
+    printf '%s\n' "$LITERAL_PERCENT_CODEX"
+    exit 1
+fi
+
+LITERAL_PERCENT_CLAUDE="$(query_claude_projects "$(build_claude_scope_predicate "$REPO_SUBDIR")" "100%" | normalize_project_rows)"
+EXPECTED_LITERAL_PERCENT_CLAUDE="$(printf '%s\n' "$(slugify_project "$REPO_MAIN")")"
+
+if [ "$LITERAL_PERCENT_CLAUDE" != "$EXPECTED_LITERAL_PERCENT_CLAUDE" ]; then
+    echo "ERROR: Claude query treated % in the keyword as a wildcard"
+    echo "Expected:"
+    printf '%s\n' "$EXPECTED_LITERAL_PERCENT_CLAUDE"
+    echo "Got:"
+    printf '%s\n' "$LITERAL_PERCENT_CLAUDE"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a Codex plugin manifest at `.codex-plugin/plugin.json`
- add Codex installation and local-development guidance while keeping the Claude slash-command form explicit
- keep shared `SKILL.md` cross-skill references client-neutral instead of emitting Claude-only slash syntax inside shared skill docs
- extend `read-memories` to cover both Claude Code and Codex with:
  - explicit Claude and Codex log paths
  - separate query blocks for each client
  - explicit `--here` guidance for each client
- require explicit `TARGET_HOME` for `skills/install-duckdb/eval-codex.sh`

## Proof
- add `eval-doc-contracts.sh` to guard the shared docs/contracts surface
- add `skills/install-duckdb/eval-codex.sh` for Codex-side install/update evaluation
- add `skills/install-duckdb/eval-codex-guard.sh` to prove `eval-codex.sh` fails cleanly without `TARGET_HOME`
- add `skills/read-memories/eval.sh` with synthetic Codex and Claude fixtures covering:
  - Codex repo/worktree scope behavior
  - Claude current-project scope behavior
  - unrelated repo exclusion
  - underscore-path false-positive exclusion
  - Claude slug-collision exclusion
  - quoted keyword/content/path handling
  - later-chunk Codex content matching
  - empty keyword rejection
  - literal `%` keyword matching

## Verification
```bash
./eval-doc-contracts.sh
./skills/install-duckdb/eval-codex-guard.sh
./skills/read-memories/eval.sh
```

Additional live Codex verification:
- in a disposable initialized Codex home, a `codex exec` smoke using `duckdb-skills:query SELECT 42` returned `VALUE=42`
- in the same disposable home, `TARGET_HOME=<disposable-codex-home> bash skills/install-duckdb/eval-codex.sh` passed with `8 passed, 0 failed`
