### PR TITLE
Add 3 new skills: `spatial`, `convert-file` and `s3-explore`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "duckdb-skills",
       "source": "./",
       "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "homepage": "https://duckdb.org",
       "repository": "https://github.com/duckdb/duckdb-skills",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb-skills",
   "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "duckdb",
     "url": "https://github.com/duckdb"

--- a/skills/convert-file/SKILL.md
+++ b/skills/convert-file/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: convert-file
+description: >
+  Convert any data file to another format: CSV, Parquet, JSON, Excel, GeoJSON, and more.
+  Use when the user says "convert to parquet", "save as xlsx", "export as JSON", "make this a CSV",
+  "turn into parquet", or any variation of format-to-format conversion for data files.
+  Also triggers when the user wants to write Parquet, Excel, or other binary formats that Claude cannot produce natively.
+argument-hint: <input-file> [output-file]
+allowed-tools: Bash
+---
+
+You are helping the user convert a data file from one format to another using DuckDB.
+
+Input file: `$0`
+Output file: `${1:-}`
+
+## Step 1 — Resolve input and output
+
+**Input**: `$0`. If it's a bare filename (no `/`), resolve to a full path with `find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null | head -1`.
+
+**Output**: If `$1` is provided, use it as the output path. If not, default to the same stem as the input with a `.parquet` extension (e.g., `data.csv` → `data.parquet`).
+
+Infer the output format from the output file extension:
+
+| Extension | Format clause |
+|---|---|
+| `.parquet`, `.pq` | *(default, no clause needed)* |
+| `.csv` | `(FORMAT csv, HEADER)` |
+| `.tsv` | `(FORMAT csv, HEADER, DELIMITER '\t')` |
+| `.json` | `(FORMAT json, ARRAY true)` |
+| `.jsonl`, `.ndjson` | `(FORMAT json, ARRAY false)` |
+| `.xlsx` | `(FORMAT xlsx)` — requires `INSTALL excel; LOAD excel;` |
+| `.geojson` | `(FORMAT GDAL, DRIVER 'GeoJSON')` — requires `LOAD spatial;` |
+| `.gpkg` | `(FORMAT GDAL, DRIVER 'GPKG')` — requires `LOAD spatial;` |
+| `.shp` | `(FORMAT GDAL, DRIVER 'ESRI Shapefile')` — requires `LOAD spatial;` |
+
+## Step 2 — Convert
+
+Run a single DuckDB command. Prepend extension loads as needed based on both the input and output formats.
+
+```bash
+duckdb -c "
+<EXTENSION_LOADS>
+COPY (FROM '<INPUT_PATH>') TO '<OUTPUT_PATH>' <FORMAT_CLAUSE>;
+"
+```
+
+For remote inputs (`s3://`, `https://`, etc.), prepend the same protocol setup as `read-file`:
+
+| Protocol | Prepend |
+|---|---|
+| `s3://` | `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| `gs://` / `gcs://` | `LOAD httpfs; CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| `https://` / `http://` | `LOAD httpfs;` |
+
+**If the user mentions partitioning** (e.g., "partition by year"), add `PARTITION_BY (col)` to the format clause. This only works with Parquet and CSV output.
+
+**If the user mentions compression** (e.g., "use zstd"), add `CODEC 'zstd'` for Parquet output.
+
+## Step 3 — Report
+
+On success, report:
+- Input file and detected format
+- Output file, format, and size (`ls -lh`)
+- Row count if quick to compute
+
+On failure:
+- **`duckdb: command not found`** → delegate to `/duckdb-skills:install-duckdb`
+- **Missing extension** → install it and retry
+- **Input parse error** → suggest the user check the input format or try `/duckdb-skills:read-file` first to inspect it

--- a/skills/s3-explore/SKILL.md
+++ b/skills/s3-explore/SKILL.md
@@ -37,18 +37,20 @@ LOAD httpfs;
 
 ## Step 2 — Determine what the URL points to
 
-If the URL looks like a **directory or bucket** (no file extension, or ends with `/`), list its contents:
+If the URL looks like a **directory or bucket** (no file extension, or ends with `/`), list its contents with sizes:
 
 ```bash
 duckdb -c "
 LOAD httpfs;
 <SECRET_SETUP>
-SELECT file, (size / 1024 / 1024)::DECIMAL(10,2) AS size_mb
-FROM glob('<URL>/*')
-ORDER BY file
+SELECT filename, (size / 1024 / 1024)::DECIMAL(10,1) AS size_mb, last_modified
+FROM read_blob('<URL>/*')
+ORDER BY filename
 LIMIT 50;
 "
 ```
+
+Note: only select `filename`, `size`, `last_modified` — never select `content`, which would download the actual files.
 
 If the URL points to a **specific file or glob pattern** (has a file extension or contains `*`), preview it:
 
@@ -62,14 +64,17 @@ FROM '<URL>' LIMIT 20;
 "
 ```
 
-For **Parquet files**, you can get metadata without reading the data:
+For **Parquet files**, get row counts and sizes from metadata (no data download):
 
 ```bash
 duckdb -c "
 LOAD httpfs;
 <SECRET_SETUP>
-SELECT file_name, num_rows, total_compressed_size / 1024 / 1024 AS compressed_mb
-FROM parquet_metadata('<URL>');
+SELECT file_name,
+       sum(row_group_num_rows) AS total_rows,
+       (sum(row_group_compressed_bytes) / 1024 / 1024)::DECIMAL(10,1) AS compressed_mb
+FROM parquet_metadata('<URL>')
+GROUP BY file_name;
 "
 ```
 

--- a/skills/s3-explore/SKILL.md
+++ b/skills/s3-explore/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: s3-explore
+description: >
+  Explore and query data on S3, Cloudflare R2, GCS, MinIO, or any S3-compatible storage.
+  Use when the user mentions an s3://, r2://, gs://, or gcs:// URL, asks "what's in this bucket",
+  wants to list remote files, preview remote Parquet/CSV/JSON, or query data on object storage
+  without downloading it. Also triggers when the user wants to know the size, schema, or row count
+  of remote datasets.
+argument-hint: <s3-url> [question about the data]
+allowed-tools: Bash
+---
+
+You are helping the user explore data on remote object storage using DuckDB.
+
+URL: `$0`
+Question: `${1:-list and describe what's there}`
+
+## Step 1 — Detect provider and set up credentials
+
+Based on the URL or user context, prepend the appropriate secret configuration:
+
+| Provider | URL patterns | Secret setup |
+|---|---|---|
+| **AWS S3** | `s3://` | `CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| **Cloudflare R2** | `r2://`, `s3://` with R2 endpoint | `CREATE SECRET (TYPE R2, PROVIDER credential_chain);` |
+| **GCS** | `gs://`, `gcs://` | `CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| **MinIO / custom** | `s3://` with custom endpoint | `CREATE SECRET (TYPE S3, KEY_ID '...', SECRET '...', ENDPOINT '...', USE_SSL true);` |
+
+For R2, if the user provides an account ID, the endpoint is `<account_id>.r2.cloudflarestorage.com`. R2 URLs like `r2://bucket/path` should be rewritten to `s3://bucket/path` with the R2 secret.
+
+For public buckets (e.g., Overture Maps, AWS open data), no secret is needed — skip this step.
+
+Always prepend:
+```sql
+LOAD httpfs;
+```
+
+## Step 2 — Determine what the URL points to
+
+If the URL looks like a **directory or bucket** (no file extension, or ends with `/`), list its contents:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+SELECT file, (size / 1024 / 1024)::DECIMAL(10,2) AS size_mb
+FROM glob('<URL>/*')
+ORDER BY file
+LIMIT 50;
+"
+```
+
+If the URL points to a **specific file or glob pattern** (has a file extension or contains `*`), preview it:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+DESCRIBE FROM '<URL>';
+SELECT count(*) AS row_count FROM '<URL>';
+FROM '<URL>' LIMIT 20;
+"
+```
+
+For **Parquet files**, you can get metadata without reading the data:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+SELECT file_name, num_rows, total_compressed_size / 1024 / 1024 AS compressed_mb
+FROM parquet_metadata('<URL>');
+"
+```
+
+## Step 3 — Answer the question
+
+Using the listing, schema, or sample data, answer:
+
+`${1:-list and describe what's there}`
+
+If the user asks an analytical question (e.g., "how many rows match X"), write and run the appropriate SQL query. DuckDB pushes predicates down into Parquet on S3, so filtering is efficient even on large remote datasets.
+
+## Error handling
+
+- **`duckdb: command not found`** → delegate to `/duckdb-skills:install-duckdb`
+- **Access denied / 403** → suggest the user check credentials: `aws configure`, environment variables, or provide explicit key/secret
+- **Bucket not found / 404** → check the URL and region
+- **Timeout on large listing** → suggest narrowing the glob pattern or adding a prefix

--- a/skills/spatial/SKILL.md
+++ b/skills/spatial/SKILL.md
@@ -39,6 +39,7 @@ For spatial function syntax, read `references/functions.md`.
 Always start with:
 ```sql
 LOAD spatial;
+SET geometry_always_xy = true;
 ```
 
 Add extensions as needed:
@@ -49,11 +50,14 @@ Add extensions as needed:
 
 **bbox filtering first** — When querying Overture, always filter on `bbox.xmin/xmax/ymin/ymax` before any spatial function. This uses Parquet predicate pushdown and avoids downloading the full dataset.
 
-**Use spheroid functions for real-world distances** — `ST_Distance_Spheroid` returns meters on the WGS84 ellipsoid. Plain `ST_Distance` uses planar coordinates and gives meaningless results for lat/lng.
+**Always set `geometry_always_xy = true`** — This ensures all spatial functions interpret coordinates as longitude, latitude (the standard for Overture, GeoJSON, and most data sources). Without it, spheroid functions assume latitude first and return wrong results.
+
+**Use spheroid functions for real-world distances** — `ST_Distance_Spheroid` returns meters on the WGS84 ellipsoid. Plain `ST_Distance` uses planar coordinates and gives meaningless results for lat/lng. **Important:** spheroid functions (`ST_Distance_Spheroid`, `ST_Area_Spheroid`, etc.) require `POINT_2D` inputs, not generic `GEOMETRY`. Overture geometry columns are typed `GEOMETRY('OGC:CRS84')` and cannot be cast directly. Extract coordinates first:
+```sql
+ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D
+```
 
 **CSV with lat/lng needs conversion** — `ST_Point(longitude, latitude)` (longitude first). This is the most common gotcha.
-
-**Set axis order for output** — Before writing KML or other formats: `SET geometry_always_xy = true;`
 
 Run the query in a single bash call:
 

--- a/skills/spatial/SKILL.md
+++ b/skills/spatial/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: spatial
+description: >
+  Answer questions about spatial data using DuckDB. Use when the user mentions locations,
+  coordinates, lat/lng, distances, maps, addresses, "near", "within", "closest", geographic
+  names, or spatial file formats (GeoJSON, Shapefile, GeoPackage, GPX, GeoParquet). Also
+  triggers when the user wants to find places, buildings, or roads — Overture Maps provides
+  free global data on S3 with zero API keys. Handles spatial joins, distance calculations,
+  containment checks, density analysis, and format conversions for geographic data.
+argument-hint: <question or file> [additional context]
+allowed-tools: Bash
+---
+
+You are answering spatial questions using DuckDB's spatial extension and, when needed, Overture Maps as a free global data source.
+
+Question or file: `$0`
+Additional context: `${1:-}`
+
+## Step 1 — Understand what the user needs
+
+Classify the question:
+
+| Pattern | Data source | Key functions |
+|---------|-------------|---------------|
+| "Find X near Y" (no user file) | Overture Maps on S3 | `ST_Distance_Spheroid`, bbox filtering |
+| "How far between A and B" | Geocode or user data | `ST_Distance_Spheroid` |
+| "Which points fall inside polygons" | User files | `ST_Contains` |
+| "Analyze this GeoJSON/Shapefile/GPX" | User file | `ST_Read`, measurement functions |
+| "Show density/hotspots" | User or Overture data | H3 hex binning |
+| "Convert to GeoJSON/GeoPackage" | User file | `COPY TO (FORMAT GDAL)` |
+| "Count buildings/roads in area" | Overture Maps | bbox filtering + aggregation |
+
+If the question involves real-world places, POIs, buildings, roads, or boundaries and the user hasn't provided a file, use **Overture Maps** — read `references/overture.md` for S3 paths and schema.
+
+For spatial function syntax, read `references/functions.md`.
+
+## Step 2 — Write and run the query
+
+Always start with:
+```sql
+LOAD spatial;
+```
+
+Add extensions as needed:
+- Overture/remote data: `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER config, REGION 'us-west-2');`
+- H3 hex binning: `INSTALL h3 FROM community; LOAD h3;`
+
+### Key principles
+
+**bbox filtering first** — When querying Overture, always filter on `bbox.xmin/xmax/ymin/ymax` before any spatial function. This uses Parquet predicate pushdown and avoids downloading the full dataset.
+
+**Use spheroid functions for real-world distances** — `ST_Distance_Spheroid` returns meters on the WGS84 ellipsoid. Plain `ST_Distance` uses planar coordinates and gives meaningless results for lat/lng.
+
+**CSV with lat/lng needs conversion** — `ST_Point(longitude, latitude)` (longitude first). This is the most common gotcha.
+
+**Set axis order for output** — Before writing KML or other formats: `SET geometry_always_xy = true;`
+
+Run the query in a single bash call:
+
+```bash
+duckdb -c "
+LOAD spatial;
+<ADDITIONAL_SETUP>
+<YOUR_QUERY>
+"
+```
+
+## Step 3 — Present results
+
+- For tabular results: show the data directly
+- For spatial results: consider exporting to GeoJSON for visualization (`COPY TO 'result.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON')`)
+- For distance/area results: use human-readable units (km for large distances, m for small)
+- For density/hotspot results: describe the pattern and offer to export for visualization
+
+If the query fails:
+- **`duckdb: command not found`** → delegate to `/duckdb-skills:install-duckdb`
+- **Missing extension** → `INSTALL spatial; LOAD spatial;` or `INSTALL h3 FROM community; LOAD h3;`
+- **S3 access denied** → suggest checking AWS credentials
+- **No results with Overture** → widen the bbox, check the category spelling, or try a broader search

--- a/skills/spatial/references/functions.md
+++ b/skills/spatial/references/functions.md
@@ -4,6 +4,7 @@
 
 ```sql
 INSTALL spatial; LOAD spatial;
+SET geometry_always_xy = true;  -- ensures lng/lat order for all spatial functions
 -- For H3 hex binning:
 INSTALL h3 FROM community; LOAD h3;
 ```
@@ -49,10 +50,15 @@ Set `geometry_always_xy = true` before writing to avoid axis order issues with K
 ### Distance & proximity
 | Function | Description |
 |----------|-------------|
-| `ST_Distance(a, b)` | Planar distance (units depend on CRS) |
-| `ST_Distance_Spheroid(a, b)` | Geodesic distance in **meters** (WGS84) |
+| `ST_Distance(a, b)` | Planar distance (units depend on CRS). Accepts any `GEOMETRY`. |
+| `ST_Distance_Spheroid(a, b)` | Geodesic distance in **meters** (WGS84). **Requires `POINT_2D` inputs** — see note below. |
 | `ST_DWithin(a, b, dist)` | Is planar distance ≤ dist? |
-| `ST_DWithin_Spheroid(a, b, dist)` | Is geodesic distance ≤ dist meters? |
+| `ST_DWithin_Spheroid(a, b, dist)` | Is geodesic distance ≤ dist meters? **Requires `POINT_2D` inputs.** |
+
+> **`POINT_2D` requirement:** Spheroid functions (`ST_Distance_Spheroid`, `ST_Area_Spheroid`, `ST_Length_Spheroid`, `ST_DWithin_Spheroid`) only accept `POINT_2D`, not generic `GEOMETRY`. Overture Maps and `ST_Read()` return `GEOMETRY` types that cannot be cast directly. Extract and rebuild:
+> ```sql
+> ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D
+> ```
 
 ### Spatial relationships
 | Function | Returns true when |

--- a/skills/spatial/references/functions.md
+++ b/skills/spatial/references/functions.md
@@ -1,0 +1,176 @@
+# DuckDB Spatial Functions Reference
+
+## Setup
+
+```sql
+INSTALL spatial; LOAD spatial;
+-- For H3 hex binning:
+INSTALL h3 FROM community; LOAD h3;
+```
+
+## Reading spatial files
+
+| Format | Read method |
+|--------|-------------|
+| GeoJSON | `ST_Read('file.geojson')` |
+| Shapefile | `ST_Read('file.shp')` |
+| GeoPackage | `ST_Read('file.gpkg')` |
+| FlatGeobuf | `ST_Read('file.fgb')` |
+| KML | `ST_Read('file.kml')` |
+| GPX | `ST_Read('file.gpx')` |
+| GeoParquet | `FROM 'file.geoparquet'` (native, no ST_Read needed) |
+| OSM PBF | `ST_ReadOSM('region.osm.pbf')` (multithreaded, tags as MAP column) |
+| CSV with lat/lng | `SELECT *, ST_Point(lng, lat) AS geom FROM 'file.csv'` |
+
+`ST_Read` uses GDAL internally and supports 50+ formats.
+
+## Writing spatial files
+
+```sql
+COPY (SELECT * FROM ...) TO 'out.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON');
+COPY (SELECT * FROM ...) TO 'out.gpkg' WITH (FORMAT GDAL, DRIVER 'GPKG');
+COPY (SELECT * FROM ...) TO 'out.shp' WITH (FORMAT GDAL, DRIVER 'ESRI Shapefile');
+COPY (SELECT * FROM ...) TO 'out.fgb' WITH (FORMAT GDAL, DRIVER 'FlatGeobuf');
+```
+
+Set `geometry_always_xy = true` before writing to avoid axis order issues with KML or WGS84.
+
+## Key functions
+
+### Construction
+| Function | Description |
+|----------|-------------|
+| `ST_Point(x, y)` | Create point from lon, lat |
+| `ST_MakeEnvelope(xmin, ymin, xmax, ymax)` | Create bounding box rectangle |
+| `ST_GeomFromText('POLYGON(...)')` | Parse WKT |
+| `ST_GeomFromGeoJSON('{"type":...}')` | Parse GeoJSON |
+| `ST_MakeLine(geom_array)` | Create line from points |
+
+### Distance & proximity
+| Function | Description |
+|----------|-------------|
+| `ST_Distance(a, b)` | Planar distance (units depend on CRS) |
+| `ST_Distance_Spheroid(a, b)` | Geodesic distance in **meters** (WGS84) |
+| `ST_DWithin(a, b, dist)` | Is planar distance ≤ dist? |
+| `ST_DWithin_Spheroid(a, b, dist)` | Is geodesic distance ≤ dist meters? |
+
+### Spatial relationships
+| Function | Returns true when |
+|----------|-------------------|
+| `ST_Contains(a, b)` | a fully contains b |
+| `ST_Within(a, b)` | a is fully within b |
+| `ST_Intersects(a, b)` | a and b share any space |
+| `ST_Covers(a, b)` | a covers b (no boundary distinction) |
+| `ST_Disjoint(a, b)` | a and b share no space |
+| `ST_Touches(a, b)` | a and b touch at boundary only |
+
+### Measurement
+| Function | Description |
+|----------|-------------|
+| `ST_Area(geom)` | Planar area |
+| `ST_Area_Spheroid(geom)` | Geodesic area in **square meters** |
+| `ST_Length(geom)` | Planar length of linestring |
+| `ST_Length_Spheroid(geom)` | Geodesic length in **meters** |
+| `ST_Perimeter(geom)` | Perimeter of polygon |
+| `ST_NPoints(geom)` | Number of vertices |
+
+### Transformation
+| Function | Description |
+|----------|-------------|
+| `ST_Transform(geom, 'EPSG:from', 'EPSG:to')` | Reproject |
+| `ST_Centroid(geom)` | Center point |
+| `ST_Buffer(geom, dist)` | Buffer/expand geometry |
+| `ST_Simplify(geom, tolerance)` | Simplify (Douglas-Peucker) |
+| `ST_ConvexHull(geom)` | Convex hull |
+| `ST_Union(a, b)` | Merge two geometries |
+| `ST_Intersection(a, b)` | Intersection of two geometries |
+| `ST_Difference(a, b)` | Subtract b from a |
+| `ST_FlipCoordinates(geom)` | Swap x/y (for axis order issues) |
+
+### Aggregation
+| Function | Description |
+|----------|-------------|
+| `ST_Extent_Agg(geom)` | Bounding box of all geometries |
+| `ST_Union_Agg(geom)` | Union of all geometries |
+| `ST_Collect(array)` | Create GeometryCollection |
+
+### Accessors
+| Function | Description |
+|----------|-------------|
+| `ST_X(point)` | Get longitude |
+| `ST_Y(point)` | Get latitude |
+| `ST_GeometryType(geom)` | Type name (POINT, POLYGON, etc.) |
+| `ST_AsText(geom)` | WKT representation |
+| `ST_AsGeoJSON(geom)` | GeoJSON representation |
+| `ST_XMin/XMax/YMin/YMax(geom)` | Bounding box coordinates |
+
+## H3 hexagonal binning
+
+H3 converts lat/lng to hexagonal cells at different resolutions. Great for density maps and hotspot analysis.
+
+| Resolution | Avg edge | Use case |
+|------------|----------|----------|
+| 0 | ~1,107 km | Continental |
+| 3 | ~59 km | Metropolitan regions |
+| 5 | ~8 km | Cities |
+| 7 | ~1.2 km | Neighborhoods |
+| 9 | ~174 m | City blocks |
+| 11 | ~25 m | Individual buildings |
+| 13 | ~3.3 m | Parking spots |
+
+Key functions:
+```sql
+-- Point to hex cell
+h3_latlng_to_cell(lat, lng, resolution) → UBIGINT
+
+-- Hex cell to center point
+h3_cell_to_latlng(cell) → STRUCT(lat, lng)
+
+-- Hex cell to polygon boundary (for visualization)
+h3_cell_to_boundary_wkt(cell) → VARCHAR (WKT)
+
+-- Ring of cells around a center
+h3_grid_disk(cell, k) → UBIGINT[] (all cells within k rings)
+
+-- Density example: count points per hex
+SELECT h3_latlng_to_cell(lat, lng, 7) AS hex,
+       count(*) AS cnt,
+       h3_cell_to_boundary_wkt(hex) AS boundary
+FROM my_points
+GROUP BY hex
+ORDER BY cnt DESC;
+```
+
+## Common patterns
+
+### CSV with lat/lng → spatial queries
+```sql
+SELECT *, ST_Point(longitude, latitude) AS geom FROM 'data.csv';
+```
+
+### Distance matrix between all pairs
+```sql
+SELECT a.name, b.name,
+       ST_Distance_Spheroid(a.geom, b.geom) AS dist_m
+FROM locations a, locations b
+WHERE a.name < b.name;
+```
+
+### Points inside polygons
+```sql
+SELECT p.name, z.zone_name
+FROM points p, zones z
+WHERE ST_Contains(z.geom, p.geom);
+```
+
+### Nearest neighbor (top-K per row)
+```sql
+SELECT a.name, b.name AS nearest,
+       ST_Distance_Spheroid(a.geom, b.geom) AS dist_m
+FROM locations a
+CROSS JOIN LATERAL (
+    SELECT name, geom FROM targets b
+    ORDER BY ST_Distance_Spheroid(a.geom, b.geom)
+    LIMIT 3
+) b;
+```

--- a/skills/spatial/references/overture.md
+++ b/skills/spatial/references/overture.md
@@ -107,7 +107,10 @@ Always filter on bbox first, then apply additional filters.
 ### Find places by category near a point
 ```sql
 SELECT names.primary, categories.primary, confidence,
-       ST_Distance_Spheroid(geometry, ST_Point(-73.985, 40.748)) AS dist_m
+       ST_Distance_Spheroid(
+         ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D,
+         ST_Point(-73.985, 40.748)::POINT_2D
+       ) AS dist_m
 FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
 WHERE bbox.xmin BETWEEN -74.01 AND -73.96
   AND bbox.ymin BETWEEN 40.72 AND 40.77
@@ -128,13 +131,19 @@ WHERE bbox.xmin BETWEEN -122.75 AND -122.55
 ```sql
 -- Find nearest Overture place to each row in user's CSV
 SELECT u.*, p.names.primary AS nearest_place, p.categories.primary AS category,
-       ST_Distance_Spheroid(ST_Point(u.longitude, u.latitude), p.geometry) AS dist_m
+       ST_Distance_Spheroid(
+         ST_Point(u.longitude, u.latitude)::POINT_2D,
+         ST_Point(ST_X(p.geometry), ST_Y(p.geometry))::POINT_2D
+       ) AS dist_m
 FROM 'user_locations.csv' u
 CROSS JOIN LATERAL (
     SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
     WHERE bbox.xmin BETWEEN u.longitude - 0.01 AND u.longitude + 0.01
       AND bbox.ymin BETWEEN u.latitude - 0.01 AND u.latitude + 0.01
-    ORDER BY ST_Distance_Spheroid(geometry, ST_Point(u.longitude, u.latitude))
+    ORDER BY ST_Distance_Spheroid(
+      ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D,
+      ST_Point(u.longitude, u.latitude)::POINT_2D
+    )
     LIMIT 1
 ) p;
 ```

--- a/skills/spatial/references/overture.md
+++ b/skills/spatial/references/overture.md
@@ -1,0 +1,140 @@
+# Overture Maps Reference
+
+Overture Maps is a free, open global dataset — POIs, buildings, roads, boundaries — distributed as GeoParquet on S3. No API keys, no downloads, no registration.
+
+## Access
+
+```sql
+LOAD httpfs;
+LOAD spatial;
+CREATE SECRET (TYPE S3, PROVIDER config, REGION 'us-west-2');
+```
+
+## S3 paths
+
+Use the STAC catalog at `https://stac.overturemaps.org/catalog.json` to find the latest release. As of 2026-03-18, the latest release is `2026-03-18.0`.
+
+Base path: `s3://overturemaps-us-west-2/release/<RELEASE>/`
+
+| Theme | Type | Path suffix |
+|-------|------|-------------|
+| Places (POIs) | place | `theme=places/type=place/*` |
+| Buildings | building | `theme=buildings/type=building/*` |
+| Transportation | segment | `theme=transportation/type=segment/*` |
+| Divisions (admin boundaries) | division | `theme=divisions/type=division/*` |
+| Division areas (polygons) | division_area | `theme=divisions/type=division_area/*` |
+| Addresses | address | `theme=addresses/type=address/*` |
+| Base (land, water, land_use) | various | `theme=base/type=land/*` etc. |
+
+## Efficient querying — bbox filtering
+
+Overture files are partitioned by bounding box. Use `bbox.*` columns for predicate pushdown — this avoids downloading the entire dataset:
+
+```sql
+FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+WHERE bbox.xmin > -74.00 AND bbox.xmax < -73.97
+  AND bbox.ymin > 40.74 AND bbox.ymax < 40.76
+```
+
+Always filter on bbox first, then apply additional filters.
+
+## Schema: Places
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | VARCHAR | Unique identifier |
+| `geometry` | GEOMETRY | Point location |
+| `bbox.xmin/xmax/ymin/ymax` | DOUBLE | Bounding box (for pushdown) |
+| `names.primary` | VARCHAR | Primary name |
+| `categories.primary` | VARCHAR | Primary category (e.g., `coffee_shop`, `restaurant`, `hospital`) |
+| `categories.alternate` | VARCHAR[] | Additional categories |
+| `confidence` | DOUBLE | 0–1 confidence score |
+| `addresses[1].freeform` | VARCHAR | Full address text |
+| `addresses[1].locality` | VARCHAR | City/town |
+| `addresses[1].country` | VARCHAR | Country code |
+| `websites` | VARCHAR[] | URLs |
+| `phones` | VARCHAR[] | Phone numbers |
+| `brand.names.primary` | VARCHAR | Brand name |
+
+## Schema: Buildings
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | VARCHAR | Unique identifier |
+| `geometry` | GEOMETRY | Polygon footprint |
+| `names.primary` | VARCHAR | Building name (often null) |
+| `class` | VARCHAR | Building class |
+| `height` | DOUBLE | Height in meters |
+| `num_floors` | INTEGER | Number of floors |
+| `roof_shape` | VARCHAR | Roof shape |
+
+## Schema: Divisions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | VARCHAR | Unique identifier |
+| `geometry` | GEOMETRY | Point (representative location) |
+| `names.primary` | VARCHAR | Division name |
+| `subtype` | VARCHAR | `country`, `region`, `county`, `locality`, etc. |
+| `admin_level` | INTEGER | Hierarchy level |
+| `population` | INTEGER | Population |
+| `country` | VARCHAR | ISO 3166-1 alpha-2 |
+
+## Schema: Division Areas (boundaries)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | VARCHAR | Unique identifier |
+| `geometry` | GEOMETRY | MultiPolygon boundary |
+| `division_id` | VARCHAR | Links to division |
+| `names.primary` | VARCHAR | Area name |
+| `subtype` | VARCHAR | Same as divisions |
+| `country` | VARCHAR | ISO 3166-1 alpha-2 |
+
+## Schema: Transportation Segments
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | VARCHAR | Unique identifier |
+| `geometry` | GEOMETRY | LineString centerline |
+| `names.primary` | VARCHAR | Road name |
+| `class` | VARCHAR | Road class (motorway, primary, secondary, tertiary, residential, etc.) |
+| `subtype` | VARCHAR | road, rail, water |
+| `speed_limits` | STRUCT[] | Speed limit rules |
+
+## Common queries
+
+### Find places by category near a point
+```sql
+SELECT names.primary, categories.primary, confidence,
+       ST_Distance_Spheroid(geometry, ST_Point(-73.985, 40.748)) AS dist_m
+FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+WHERE bbox.xmin BETWEEN -74.01 AND -73.96
+  AND bbox.ymin BETWEEN 40.72 AND 40.77
+  AND categories.primary = 'coffee_shop'
+ORDER BY dist_m
+LIMIT 10;
+```
+
+### Count buildings in a city
+```sql
+SELECT count(*) AS buildings
+FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=buildings/type=building/*')
+WHERE bbox.xmin BETWEEN -122.75 AND -122.55
+  AND bbox.ymin BETWEEN 45.45 AND 45.60;
+```
+
+### Join user data with Overture
+```sql
+-- Find nearest Overture place to each row in user's CSV
+SELECT u.*, p.names.primary AS nearest_place, p.categories.primary AS category,
+       ST_Distance_Spheroid(ST_Point(u.longitude, u.latitude), p.geometry) AS dist_m
+FROM 'user_locations.csv' u
+CROSS JOIN LATERAL (
+    SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+    WHERE bbox.xmin BETWEEN u.longitude - 0.01 AND u.longitude + 0.01
+      AND bbox.ymin BETWEEN u.latitude - 0.01 AND u.latitude + 0.01
+    ORDER BY ST_Distance_Spheroid(geometry, ST_Point(u.longitude, u.latitude))
+    LIMIT 1
+) p;
+```


### PR DESCRIPTION
Those 3 are still experimental, in the sense that they have seen very little mileage/usage.

Idea for all three is pretty simple, look for strength of duckdb that could expand Claude capabilities / that can integrate nicely with Claude.

* `convert-file`: convert between file formats
* `spatial`: query any spatial dataset OR respond to any spatial query ("I am in Hyde Park, London, what are the nearest hospitals?") using as backbone duckdb's spatial extension and overture maps as open available dataset.
* `s3-explore`: explore content of S3 (AWS, Cloudflare, GCS, Minio) buckets. Basics are globs, but Claude can then refine SQL.

Also bump version to `0.2.4`.
Build with the help of skill-builder meta-skill.